### PR TITLE
fix(hacs): switch to git-checkout install (zip_release: false)

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,8 +1,7 @@
 {
   "name": "PadSpan HA",
   "content_in_root": false,
-  "zip_release": true,
-  "filename": "padspan_ha.zip",
+  "zip_release": false,
   "render_readme": true,
   "homeassistant": "2024.1.0"
 }


### PR DESCRIPTION
## Problem

HACS fails to download this integration with errors like:

\`\`\`
Failed to download https://github.com/gbroeckling/padspanHA/releases/download/tags/v0.20.54/padspan_ha.zip
\`\`\`

The URL HACS generates has an extra \`/tags/\` segment — the correct URL is \`…/releases/download/v0.20.54/padspan_ha.zip\` (without \`tags/\`). The 404 happens on every release tag tried (v0.20.40, v0.20.54, v0.20.62).

This appears to be a HACS-side bug in how it constructs the release-asset URL for some repos using \`zip_release: true\`. Reproduced on HACS 2.0.5 against HA 2026.5.2.

## Fix

Flip \`zip_release: true\` → \`false\` in \`hacs.json\`. HACS then installs by cloning the repo and copying \`custom_components/padspan_ha/\` directly into the user's \`/config/custom_components/\`, bypassing the broken release-asset URL path entirely.

The integration files in \`custom_components/padspan_ha/\` are already present in the repo, so no other changes are needed.

## Trade-offs

- ✅ Works on HACS today without waiting for an upstream HACS fix
- ✅ Future releases tagged as \`vX.Y.Z\` continue to work — HACS just picks up the latest tag
- ⚠️ Install pulls slightly more (full repo checkout vs. the zip release) — a few hundred KB more
- ⚠️ Loses the cosmetic \"download asset\" tracking in HACS UI

Once the upstream HACS bug is fixed, you can revert this and restore \`zip_release: true\`.

## Testing

Tested install via HACS custom repository on HA 2026.5.2:
1. Add \`dgshue/padspanHA\` as a custom HACS Integration repository
2. Download — succeeds (where the unforked repo fails with the URL above)
3. Restart HA
4. Integration loads, config flow appears under Settings → Devices & Services