### PR TITLE
Persist room_tag_map across restarts

### DIFF
--- a/custom_components/padspan_ha/__init__.py
+++ b/custom_components/padspan_ha/__init__.py
@@ -350,7 +350,14 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             hass.data[DOMAIN]["coordinator"] = coord
         coord.room_tag_map = call.data.get("room_tag_map") or {}
         coord.mark_success()
-        _LOGGER.info("room_tag_map replaced via service (%d rooms)", len(coord.room_tag_map))
+        # Persist so the map survives restarts/reloads (was in-memory only).
+        try:
+            _settings = hass.data.get(DOMAIN, {}).get(DATA_SETTINGS)
+            if _settings:
+                await _settings.async_set(room_tag_map=coord.room_tag_map)
+        except Exception as err:
+            _LOGGER.exception("Failed to persist room_tag_map: %s", err)
+        _LOGGER.info("room_tag_map replaced via service (%d rooms, persisted)", len(coord.room_tag_map))
 
     hass.services.async_register(DOMAIN, SERVICE_SET_MAP, _set_map, schema=SERVICE_SCHEMA)
 
@@ -437,6 +444,25 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     coord.api_key = str(entry.data.get(CONF_API_KEY, ""))
     coord.scan_interval = int(entry.options.get(CONF_SCAN_INTERVAL, entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)))
     coord.ensure_defaults()
+
+    # Restore the persisted room_tag_map.  It is saved into SettingsStore by the
+    # set_room_tag_map service; without this load the coordinator starts empty on
+    # every restart/reload, which blanks the Diagnostics check and the room→object
+    # map the UI falls back to.  Only restore when the live coordinator has none,
+    # so an in-session service update is never clobbered by a reload.
+    try:
+        _settings = hass.data.get(DOMAIN, {}).get(DATA_SETTINGS)
+        if _settings and not coord.room_tag_map:
+            _saved_rtm = _settings.get("room_tag_map") or {}
+            if isinstance(_saved_rtm, dict) and _saved_rtm:
+                coord.room_tag_map = {
+                    str(room): [str(k) for k in keys]
+                    for room, keys in _saved_rtm.items()
+                    if isinstance(keys, (list, tuple))
+                }
+                _LOGGER.info("Restored persisted room_tag_map (%d rooms)", len(coord.room_tag_map))
+    except Exception as err:
+        _LOGGER.exception("Failed to restore persisted room_tag_map: %s", err)
 
     # Ensure room metadata exists for all rooms
     try:

--- a/custom_components/padspan_ha/services.yaml
+++ b/custom_components/padspan_ha/services.yaml
@@ -1,6 +1,6 @@
 set_room_tag_map:
   name: "Set Room Tag Map"
-  description: "Replace the in-memory room_tag_map (for testing)."
+  description: "Replace the curated room_tag_map (room name → list of object keys). Persisted across restarts."
   fields:
     room_tag_map:
       required: true

--- a/custom_components/padspan_ha/settings_store.py
+++ b/custom_components/padspan_ha/settings_store.py
@@ -99,6 +99,11 @@ DEFAULT_SETTINGS: dict[str, Any] = {
     "beacon_group_overrides": {},         # device_id → model_key override (ungroup/regroup)
     # Private BLE IRK devices (managed in PadSpan — no separate integration needed)
     "irk_devices": [],                    # [{name: str, irk_hex: str}]
+    # Curated room → object map (room name → list of object keys).  Set via the
+    # padspan_ha.set_room_tag_map service / Manage UI.  Persisted here so it
+    # survives restarts and integration reloads — previously the coordinator's
+    # room_tag_map was in-memory only and reset to {} on every restart.
+    "room_tag_map": {},                   # {room_name: [object_key, ...]}
     # ── Enterprise preview features (off by default) ─────────────────────────
     "trackability_rating_enabled": False,   # per-device Easy/Medium/Hard trackability score
     "walk_to_identify_enabled": False,      # spatial correlation device discovery ("who just walked in?")


### PR DESCRIPTION
## Problem

The coordinator's `room_tag_map` was only ever set in memory by the `padspan_ha.set_room_tag_map` service. It was never loaded from storage on startup, so it reset to `{}` on every Home Assistant restart or integration reload.

Visible symptoms after any restart:
- Manage → Diagnostics `room_tag_map` health check fails ("No room/tag data loaded") even though rooms were configured.
- The room→object map that `padspan_ha/room_tags` falls back to (`effective = saved_map if saved_map else live_map`) is empty, so the UI loses the user's curated model until the service is manually called again.

This is the same persistence class as the previously-fixed map/room issues (#20, #22, #24); `room_tag_map` was the one curated structure left in-memory.

## Fix

Persist it in `SettingsStore`, alongside the other curated dict maps already stored there (`scanner_offsets`, `espresense_room_map`, `beacon_group_overrides`):

- add `room_tag_map` to `DEFAULT_SETTINGS`
- restore it into the coordinator during `async_setup_entry`, **only when the live coordinator has none** so an in-session service update is never clobbered by a reload
- save it whenever `set_room_tag_map` runs
- update the service description (no longer in-memory / testing-only)

No new store, no config-entry migration — uses the already-loaded critical store and preserves unknown keys on merge.

## Testing

Verified on a live HA container (v0.20.69):
1. `set_room_tag_map` with 4 rooms / 29 objects → written to `.storage/padspan_ha.settings`.
2. `auto_diagnostics` goes 2/3 → **3/3** (`room_tag_map: 4 rooms loaded`).
3. Full HA restart with **no re-seed** → log shows `Restored persisted room_tag_map (4 rooms)`, `status` and diagnostics remain populated.