### PR TITLE
Add device information properties

### DIFF
--- a/custom_components/padspan_ha/sensor.py
+++ b/custom_components/padspan_ha/sensor.py
@@ -33,6 +33,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.helpers import device_registry as dr
 
 from .const import DOMAIN, DATA_SETTINGS, DEFAULT_REF_POWER, DEFAULT_PATH_LOSS_EXP
 from .presence_coordinator import PresenceCoordinator
@@ -227,11 +228,17 @@ class PadSpanAreaSensor(CoordinatorEntity[PresenceCoordinator], SensorEntity):
     @property
     def device_info(self) -> dict[str, Any]:
         uid = _device_uid(self._obj) or self._init_uid
+        address = self._obj.get("address")
+        model_id = self._obj.get("kind")
+        serial_number = self._obj.get("padspan_id")
         return {
             "identifiers": {(DOMAIN, uid)},
             "name": self._label(),
             "manufacturer": "PadSpan HA",
             "model": "BLE Presence Tracker",
+            "model_id": model_id,
+            "serial_number": serial_number,
+            "connections": {(dr.CONNECTION_BLUETOOTH, address)}
         }
 
     # ── state ─────────────────────────────────────────────────────────────────
@@ -316,11 +323,17 @@ class PadSpanDistanceSensor(CoordinatorEntity[PresenceCoordinator], SensorEntity
     @property
     def device_info(self) -> dict[str, Any]:
         uid = _device_uid(self._obj) or self._init_uid
+        address = self._obj.get("address")
+        model_id = self._obj.get("kind")
+        serial_number = self._obj.get("padspan_id")
         return {
             "identifiers": {(DOMAIN, uid)},
             "name": self._label(),
             "manufacturer": "PadSpan HA",
             "model": "BLE Presence Tracker",
+            "model_id": model_id,
+            "serial_number": serial_number,
+            "connections": {(dr.CONNECTION_BLUETOOTH, address)}
         }
 
     @property
@@ -396,11 +409,17 @@ class PadSpanScannerDistanceSensor(CoordinatorEntity[PresenceCoordinator], Senso
     @property
     def device_info(self) -> dict[str, Any]:
         uid = _device_uid(self._obj) or self._init_uid
+        address = self._obj.get("address")
+        model_id = self._obj.get("kind")
+        serial_number = self._obj.get("padspan_id")
         return {
             "identifiers": {(DOMAIN, uid)},
             "name": self._label(),
             "manufacturer": "PadSpan HA",
             "model": "BLE Presence Tracker",
+            "model_id": model_id,
+            "serial_number": serial_number,
+            "connections": {(dr.CONNECTION_BLUETOOTH, address)}
         }
 
     @property


### PR DESCRIPTION
I added

padspan_id as serial number
kind as model_id

<img width="402" height="221" alt="image" src="https://github.com/user-attachments/assets/9d3b8a99-8306-49f5-a3e8-4ff0c45dba19" />

And the address as bluetooth connection

So the homeassistant can identifie the addresses

<img width="1304" height="938" alt="image" src="https://github.com/user-attachments/assets/c19646f4-a962-4ea4-8f28-08c248326afc" />
