### PR TITLE
events: only fire arrive/depart bus events for labelled devices

### DIFF
--- a/custom_components/padspan_ha/presence_coordinator.py
+++ b/custom_components/padspan_ha/presence_coordinator.py
@@ -2139,23 +2139,31 @@ class PresenceCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 if isinstance(entry, dict) and entry.get("label"):
                     _key_labels[str(k)] = entry["label"]
 
-        # ── Fire HA events for every arrive/depart ───────────────────────
-        # These events can be used as triggers in HA automations.
+        # ── Fire HA events for labelled arrive/depart ────────────────────
+        # These events can be used as triggers in HA automations.  Only
+        # labelled (user-tagged) devices fire: every rotating-MAC rotation in
+        # a busy BLE environment registers as a "new" unlabelled arrival, and
+        # firing those flooded the event bus until subscribers hit HA's
+        # 4096-pending-message limit and were disconnected.  PadSpan's own
+        # automation rules below match on the raw arrived/departed sets, so
+        # rules keyed to an unlabelled device still run.
         for key in arrived:
             label = _key_labels.get(key, "")
+            if not label:
+                continue
             room = (result.get(key) or {}).get("room", "")
             self.hass.bus.async_fire("padspan_device_arrived", {
                 "device_key": key, "label": label, "room": room,
             })
-            if label:
-                _LOGGER.info("Device arrived: %s (%s) in %s", label, key[:30], room)
+            _LOGGER.info("Device arrived: %s (%s) in %s", label, key[:30], room)
         for key in departed:
             label = _key_labels.get(key, "")
+            if not label:
+                continue
             self.hass.bus.async_fire("padspan_device_departed", {
                 "device_key": key, "label": label,
             })
-            if label:
-                _LOGGER.info("Device departed: %s (%s)", label, key[:30])
+            _LOGGER.info("Device departed: %s (%s)", label, key[:30])
 
         # ── Execute PadSpan automation rules ─────────────────────────────
         try:


### PR DESCRIPTION
## What broke

Every rotating-MAC (RPA) rotation registers as a new unlabelled object. The coordinator fired a `padspan_device_arrived` bus event for each such "arrival" and `padspan_device_departed` for each drop. In a busy BLE environment this fired continuously.

On the fork's production box the volume overran Home Assistant's 4096-pending-message limit on the event bus every hour, and HA force-disconnected the websocket subscribers, including the frontend panel. The map went blank until the connection re-established.

## The change

Gate the `padspan_device_arrived` / `padspan_device_departed` bus events on a non-empty label, so only user-tagged devices fire them. Unlabelled rotating-MAC churn no longer touches the event bus.

PadSpan's own automation rules later in `_run_automations` match against the raw `arrived` / `departed` sets, so a rule keyed to an unlabelled device key still runs. The info-log lines are unchanged; they already logged only when a label was present.

## Testing

One-function edit to `presence_coordinator._run_automations`. Full test suite passes (202 tests). No test exercised the event-firing path before or after.

From a downstream fork running the integration in production.
