### PR TITLE
presence: drop orphaned Kalman state when the RPA resolver flaps

### DIFF
--- a/custom_components/padspan_ha/presence_coordinator.py
+++ b/custom_components/padspan_ha/presence_coordinator.py
@@ -784,6 +784,15 @@ class PresenceCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 # For private_ble, use canonical_id as Kalman state key so all
                 # rotating MACs share one continuous smoothing state.
                 smooth_addr = _rpa_map.get(raw_addr, raw_addr)
+                # If the resolver flapped (canonical <-> raw between polls),
+                # the mapping changes and the old key's Kalman state would be
+                # orphaned forever (eviction only pops the current mapping).
+                # Drop the superseded state; it re-seeds on the next poll.
+                _prev_addr = self._kalman_addr_key.get(key)
+                if _prev_addr and _prev_addr not in (smooth_addr, key):
+                    self._ema_rssi.pop(_prev_addr, None)
+                    self._kalman_p.pop(_prev_addr, None)
+                    self._silence_miss.pop(_prev_addr, None)
                 self._kalman_addr_key[key] = smooth_addr
                 smoothed_room = self._smooth_room(
                     key, smooth_addr, addr_src_rssi, source_to_area,


### PR DESCRIPTION
## What broke

For a `private_ble` device the coordinator keys its Kalman/EMA smoothing state under the resolved canonical address (`smooth_addr`) so every rotating MAC shares one smoothing state. The current mapping is stored in `self._kalman_addr_key[key]`.

When the resolver flaps (the canonical-to-raw mapping toggles between two polls), `smooth_addr` changes, but `_evict_object` only pops the state under the current mapping. The superseded key's entries in `_ema_rssi`, `_kalman_p`, and `_silence_miss` are never reclaimed and leak for the process lifetime, one per flap.

## The change

Before writing the new mapping, read the previous `smooth_addr` for this key. If it differs from both the new `smooth_addr` and the bare key, pop its `_ema_rssi` / `_kalman_p` / `_silence_miss` entries. The state re-seeds on the next poll, so there is no accuracy cost.

## Testing

Nine-line addition in the smoothing path of `_async_update_data`. Full test suite passes (202 tests).

Found during merge QC on a downstream fork; the leak is pre-existing upstream behaviour.
