### PR TITLE
Tune receiver positioning save fix

### DIFF
--- a/custom_components/padspan_ha/www/padspan-ha/views/calibration.js
+++ b/custom_components/padspan_ha/www/padspan-ha/views/calibration.js
@@ -47,8 +47,14 @@ function _metresToFracFactory(model) {
   };
 }
 
-const { mapXform, worldGauge, metresToWorld } =
+const { mapXform, worldGauge, metresToWorld, mapFracToMetres,
+        metresToMapFrac } =
   await import(`./stack_transform.js${new URL(import.meta.url).search}`);
+const { tuneSavePlanInit, tuneDiffMapDraft, tuneMissingFabricPins, tuneConflictingSources,
+        tuneReconcileDraft, tuneSyncTuneDrafts, tuneSnapBaseline,
+        tuneTryAcquire, tuneRelease } =
+  await import(`./tune_save_plan.js${new URL(import.meta.url).search}`);
+tuneSavePlanInit({ mapFracToMetres, metresToMapFrac });
 
 // ── Exports ──────────────────────────────────────────────────────────────────
 export function render(ctx) {
@@ -2069,26 +2075,16 @@ function _tuneTab(ctx, el, cs, calData) {
   };
   const ts = ctx.state._calibTune;
 
-  // Build a stamp from maps data to detect external updates
-  const mapsStamp = maps_list.map(m => `${m.id}:${m.updated||""}:${(m.receivers||[]).length}`).join("|");
-  const hasDirty = Object.values(ts.dirtyMaps).some(Boolean);
-
-  // Re-sync draft receivers when maps data changes externally (and no unsaved edits)
-  // Keep ALL stored receivers — do not filter by live status (radios may not have reconnected yet)
-  if (!Object.keys(ts.draftReceivers).length || (mapsStamp !== ts._mapsStamp && !hasDirty)) {
-    for (const m of maps_list) {
-      ts.draftReceivers[m.id] = (m.receivers || [])
-        .map(r => ({
-          id: r.id || r.source || ("rx_" + Math.random().toString(16).slice(2, 10)), label: r.label || "", x: Number(r.x || 0), y: Number(r.y || 0), room: r.room || "", source: r.source || ""
-        }));
-    }
-    // Remove drafts for maps that no longer exist
-    for (const id of Object.keys(ts.draftReceivers)) {
-      if (!maps_list.find(m => m.id === id)) delete ts.draftReceivers[id];
-    }
-    ts._mapsStamp = mapsStamp;
-  }
-
+  // Single authoritative draft-sync, shared by initial render and
+  // Reset (see tuneSyncTuneDrafts): seeds empty drafts, reseeds CLEAN
+  // maps on metadata change, and reconciles clean drafts from the fabric
+  // whenever maps OR model data changed — a model arriving after the
+  // initial map-seeded render is the normal first-paint order. Dirty
+  // drafts (unsaved edits, failed writes) are never touched here.
+  tuneSyncTuneDrafts(ts, maps_list,
+    (ctx.state.model || {}).scanner_positions_m || {},
+    (ctx.state.model || {}).map_transforms || {});
+  const hasDirty = Object.values(ts.dirtyMaps || {}).some(Boolean);
   let _fg = ts.fg, _hg = ts.hg;
 
   // ── Transforms ────────────────────────────────────────────────────────────
@@ -2365,6 +2361,7 @@ function _tuneTab(ctx, el, cs, calData) {
       rxObj.x = nx;
       rxObj.y = ny;
       ts.dirtyMaps[mapId] = true;
+      ts._tuneRev = (ts._tuneRev || 0) + 1;
       const [newWx, newWy] = xf.mapPt(nx, ny);
       const [newPx, newPy] = iso(newWx, newWy, z);
       g.setAttribute("transform", `translate(${newPx - origPx},${newPy - origPy})`);
@@ -2416,6 +2413,7 @@ function _tuneTab(ctx, el, cs, calData) {
     if (!ts.draftReceivers[m.id]) ts.draftReceivers[m.id] = [];
     ts.draftReceivers[m.id].push(newRx);
     ts.dirtyMaps[m.id] = true;
+    ts._tuneRev = (ts._tuneRev || 0) + 1;
     ts.selectedRx = { mapId: m.id, rxId: newRx.id };
     ts.pendingPlace = null;
     ts._confirming = false;
@@ -2629,25 +2627,183 @@ function _tuneTab(ctx, el, cs, calData) {
   saveBtn.textContent = hasDirty ? "\ud83d\udcbe Save" : "Save";
   saveBtn.title = "Save updated receiver positions to all modified maps";
   saveBtn.addEventListener("click", async () => {
-    const dirtyIds = Object.keys(ts.dirtyMaps).filter(id => ts.dirtyMaps[id]);
-    if (!dirtyIds.length) { statusLbl.textContent = "No changes"; setTimeout(() => { statusLbl.textContent = ""; }, 2000); return; }
+    // Mutual exclusion across same-session fabric writers (this save,
+    // Height saves, removals): acquire BEFORE the first request, release
+    // unconditionally. A busy session toasts and changes nothing — there
+    // is deliberately no queue.
+    if (!tuneTryAcquire(ts)) {
+      ctx.toast("A save is in progress — try again in a moment", true);
+      return;
+    }
     saveBtn.disabled = true;
     statusLbl.textContent = "Saving...";
+    // Draft edits landing while this save is in flight bump ts._tuneRev;
+    // the save below never clears what it did not itself write.
+    const _revAtStart = ts._tuneRev || 0;
     try {
-      // Save to fabric (metre-space authority), then sync fracs back to maps
+      // Edit intent is difference-from-baseline per source. Convertible
+      // pins missing from the fabric join even from clean maps — a
+      // placed-but-never-saved pin must not read "No changes". Untouched
+      // rows never post, however stale.
+      const _model = ctx.state.model || {};
+      const _fabBase = JSON.parse(JSON.stringify(
+        _model.scanner_positions_m || {}));
+      const _tfs = _model.map_transforms || {};
+      for (const { mapId } of tuneMissingFabricPins(maps_list,
+          ts.draftReceivers, _fabBase, _tfs)) {
+        ts.dirtyMaps[mapId] = true;
+      }
+      const dirtyIds = Object.keys(ts.dirtyMaps).filter(id => ts.dirtyMaps[id]);
+      if (!dirtyIds.length) {
+        statusLbl.textContent = "No changes";
+        setTimeout(() => { statusLbl.textContent = ""; }, 2000);
+        return;
+      }
+      let _ok = 0;
+      const _failedMaps = {};
+      const _failedSources = {};
+      // Transaction candidates: map/source/exact snapshot fractions,
+      // with metadata (label/room) kept OUT of the WS payload.
+      const _cands = [];
       for (const mapId of dirtyIds) {
         const origMap = maps_list.find(m => m.id === mapId);
-        if (!origMap) continue;
+        if (!origMap) { _failedMaps[mapId] = true; continue; }
+        const _base = ((ts.editBaseline || {})[mapId]) || {};
+        const _plan = tuneDiffMapDraft(
+          origMap, ts.draftReceivers[mapId] || [], _fabBase, _tfs,
+          _base, true);
+        if (!_plan || _plan.refused) { _failedMaps[mapId] = true; continue; }
+        for (const _badSrc of (_plan.invalid || [])) {
+          _failedMaps[mapId] = true;
+          (_failedSources[mapId] = _failedSources[mapId] || {})[_badSrc] = true;
+        }
+        const _rows = ts.draftReceivers[mapId] || [];
+        for (const w of _plan.writes) {
+          const _row = _rows.find(r => (r && r.source) === w.source);
+          _cands.push({ mapId, source: w.source,
+            x: _row ? _row.x : null, y: _row ? _row.y : null,
+            label: _row ? (_row.label || "") : "",
+            room: _row ? (_row.room || "") : "",
+            payload: { type: "padspan_ha/fabric_scanner_position_set",
+              source: w.source, x_m: w.x_m, y_m: w.y_m,
+              floor_id: w.floor_id,
+              ...(w.z_m !== undefined ? { z_m: w.z_m } : {}) } });
+        }
       }
-      // Clear dirty state BEFORE refresh so re-rendered view shows clean state
-      ts.dirtyMaps = {};
-      ts.selectedRx = null;
-      ctx.toast("Receiver positions saved");
-      // mapsRefresh refreshes data + triggers re-render (which updates dirty label & stamp)
+      // Conflicts across ALL candidates (missing pins included) refuse
+      // every owner; then group the survivors by source — one payload per
+      // source no matter how many maps carry it. A failed request keeps
+      // ALL of its owners pending; _ok counts unique requests.
+      const _payloads = _cands.map(c => c.payload);
+      for (const _bad of tuneConflictingSources(_payloads)) {
+        for (const c of _cands) {
+          if (c.source === _bad) {
+            _failedMaps[c.mapId] = true;
+            (_failedSources[c.mapId] = _failedSources[c.mapId] || {})[_bad] = true;
+          }
+        }
+      }
+      const _txns = [];
+      for (const c of _cands) {
+        // Planning-failed maps (refused/invalid/missing) and conflicted
+        // sources never reach the wire; every one of their owners stays
+        // pending via the dirty flags below.
+        if (_failedMaps[c.mapId]) continue;
+        if ((_failedSources[c.mapId] || {})[c.source]) continue;
+        const _hit = _txns.find(t => t.source === c.source);
+        if (_hit) { _hit.owners.push({ mapId: c.mapId, x: c.x, y: c.y }); continue; }
+        _txns.push({ source: c.source, payload: c.payload,
+          owners: [{ mapId: c.mapId, x: c.x, y: c.y }] });
+      }
+      for (const t of _txns) {
+        if (_revAtStart !== (ts._tuneRev || 0)) break;
+        try {
+          const _res = await ctx.actions.callWS(t.payload);
+          // A transport-level resolve carrying ok:false is still a
+          // failure — never clear dirty on it.
+          if (_res && _res.ok === false) {
+            for (const o of t.owners) {
+              _failedMaps[o.mapId] = true;
+              (_failedSources[o.mapId] = _failedSources[o.mapId] || {})[t.source] = true;
+            }
+            continue;
+          }
+          _ok++;
+          // The baseline advances ONLY to the SUBMITTED snapshot — never
+          // to the mutable current draft, which may already hold newer
+          // edits. The ack is published locally so a swallowed refresh
+          // failure cannot revert it; rejected/conflicting/unsubmitted
+          // rows never advance.
+          ts.editBaseline = ts.editBaseline || {};
+          try {
+            const _lm = ctx.state.model || (ctx.state.model = {});
+            const _lspm = _lm.scanner_positions_m ||
+              (_lm.scanner_positions_m = {});
+            _lspm[t.source] = { x_m: t.payload.x_m, y_m: t.payload.y_m,
+              z_m: (t.payload.z_m !== undefined ? t.payload.z_m :
+                (((_lspm[t.source] || {}).z_m !== undefined) ?
+                  _lspm[t.source].z_m : 2.4)),
+              floor_id: t.payload.floor_id };
+          } catch (_e) { /* publication is best-effort */ }
+          for (const o of t.owners) {
+            ts.editBaseline[o.mapId] = ts.editBaseline[o.mapId] || {};
+            ts.editBaseline[o.mapId][t.source] = { x: o.x, y: o.y };
+          }
+        } catch (e) {
+          for (const o of t.owners) {
+            _failedMaps[o.mapId] = true;
+            (_failedSources[o.mapId] = _failedSources[o.mapId] || {})[t.source] = true;
+          }
+        }
+      }
+      const _failCount = Object.keys(_failedMaps).filter(id => _failedMaps[id]).length;
+      if (_revAtStart !== (ts._tuneRev || 0)) {
+        // Concurrent edit landed mid-save: report, keep every dirty flag
+        // the save did not itself clear, and let the newer state win —
+        // a retry sends the newer edit (its baseline still differs).
+        statusLbl.textContent = `Saved ${_ok} — map changed during save, review`;
+        ctx.toast(`Saved ${_ok}; edits changed during save — review before re-saving`, true);
+        saveBtn.disabled = false;
+      } else if (_failCount) {
+        ts.dirtyMaps = _failedMaps;
+        statusLbl.textContent = `Saved ${_ok}, failed ${_failCount} map(s)`;
+        ctx.toast(`Saved ${_ok} receiver(s), ${_failCount} map(s) failed — kept unsaved`, true);
+        saveBtn.disabled = false;
+      } else {
+        ts.dirtyMaps = {};
+        ts.selectedRx = null;
+        ctx.toast("Receiver positions saved");
+      }
+      // mapsRefresh alone does not refresh the model the height input reads
+      // (scanner_positions_m) — refresh both so new entries expose Save Z.
       await ctx.actions.mapsRefresh();
+      if (ctx.actions.modelRefresh) await ctx.actions.modelRefresh();
+      // Reconcile CLEAN drafts from authoritative fabric (inverse
+      // transform): saved moves stop reverting on Reset/fresh session and
+      // Tune-added pins stop vanishing. Failed/dirty maps are untouched,
+      // and reconciled rows advance their baselines so the reconcile
+      // itself never reads as a new edit.
+      try {
+        const _fabNow = (ctx.state.model && ctx.state.model.scanner_positions_m) || {};
+        const _tfsNow = (ctx.state.model && ctx.state.model.map_transforms) || {};
+        if (_revAtStart === (ts._tuneRev || 0)) {
+          for (const m of maps_list) {
+            if ((ts.dirtyMaps || {})[m.id]) continue;
+            const _next = tuneReconcileDraft(
+              m, ts.draftReceivers[m.id] || [], _fabNow, _tfsNow, false);
+            if (_next) {
+              ts.draftReceivers[m.id] = _next;
+              ts.editBaseline[m.id] = tuneSnapBaseline(_next);
+            }
+          }
+        }
+      } catch (e) { /* reconcile is best-effort; the save already landed */ }
     } catch (e) {
       ctx.toast("Save failed: " + String(e), true);
       statusLbl.textContent = "Error saving";
+      saveBtn.disabled = false;
+    } finally {
+      tuneRelease(ts);
       saveBtn.disabled = false;
     }
   });
@@ -2659,16 +2815,30 @@ function _tuneTab(ctx, el, cs, calData) {
   resetBtn.textContent = "Reset";
   resetBtn.title = "Discard unsaved changes and reload receiver positions";
   resetBtn.addEventListener("click", () => {
-    ts.draftReceivers = {};
-    for (const m of maps_list) {
-      ts.draftReceivers[m.id] = (m.receivers || [])
-        .map(r => ({
-          id: r.id || r.source || ("rx_" + Math.random().toString(16).slice(2, 10)), label: r.label || "", x: Number(r.x || 0), y: Number(r.y || 0), room: r.room || "", source: r.source || ""
-        }));
+    // Guard first: a Reset landing mid-save must not tear down the
+    // drafts the in-flight save is reading. Busy returns unchanged.
+    if (!tuneTryAcquire(ts)) {
+      ctx.toast("A save is in progress — try again in a moment", true);
+      return;
     }
-    ts.dirtyMaps = {};
-    ts.selectedRx = null;
-    ts.pendingPlace = null;
+    try {
+      ts._tuneRev = (ts._tuneRev || 0) + 1;
+      // Clear dirty flags, drafts AND baselines BEFORE re-syncing, so the
+      // shared routine takes its fresh path against the current
+      // acknowledged model (which carries every ack the save published,
+      // even when a refresh was swallowed). No new stamp mechanism: empty
+      // drafts already select the fresh path.
+      ts.dirtyMaps = {};
+      ts.draftReceivers = {};
+      ts.editBaseline = {};
+      tuneSyncTuneDrafts(ts, maps_list,
+        (ctx.state.model || {}).scanner_positions_m || {},
+        (ctx.state.model || {}).map_transforms || {});
+      ts.selectedRx = null;
+      ts.pendingPlace = null;
+    } finally {
+      tuneRelease(ts);
+    }
     ts.fg = ctx.state.settings?.overview_iso_floor_gap ?? 150;
     ts.hg = ctx.state.settings?.overview_iso_horiz_gap ?? 0;
     ts.focusIdx = 0;
@@ -2749,12 +2919,48 @@ function _tuneTab(ctx, el, cs, calData) {
       zBtn.title = "Mounting height above this scanner's own floor. Used for 3D distance; survives map syncs.";
       zBtn.addEventListener("click", async () => {
         const v = parseFloat(zInp.value);
-        if (!isFinite(v) || v < 0 || v > 100) { ctx.toast("Height must be 0–100 m", true); return; }
+        if (!Number.isFinite(v) || v < 0 || v > 100) {
+          ctx.toast("Height must be 0–100 m", true);
+          return;
+        }
+        // The lock is owned by this ENTIRE callback: acquired before the
+        // request, held through the acknowledged local update AND the
+        // awaited refresh, released unconditionally. A concurrent
+        // position save or removal is refused while held, and vice versa.
+        if (!tuneTryAcquire(ts)) {
+          ctx.toast("A save is in progress — try again in a moment", true);
+          return;
+        }
         try {
-          await ctx.actions.callWS({ type: "padspan_ha/fabric_scanner_z_set", source: rx.source, z_m: v });
+          const _hres = await ctx.actions.callWS({
+            type: "padspan_ha/fabric_scanner_z_set",
+            source: rx.source, z_m: v,
+          });
+          if (_hres && _hres.ok === false) {
+            ctx.toast("Save failed: height not stored", true);
+            return;
+          }
+          // Publish the ACKNOWLEDGED height locally before refreshing:
+          // modelRefresh swallows fetch errors, so a failed refresh must
+          // not lose the ack. Backend rounds to 2dp within 0–100.
+          try {
+            const _mdl = ctx.state.model || (ctx.state.model = {});
+            const _spm = _mdl.scanner_positions_m ||
+              (_mdl.scanner_positions_m = {});
+            const _hprev = _spm[rx.source];
+            _spm[rx.source] = {
+              ...(_hprev && typeof _hprev === "object" ? _hprev : {}),
+              z_m: Math.round(Math.max(0, Math.min(100, v)) * 100) / 100,
+            };
+          } catch (_e) { /* publication is best-effort */ }
           ctx.toast(`${rx.label || rx.source}: height set to ${v} m`);
-          ctx.actions.modelRefresh && ctx.actions.modelRefresh();
-        } catch (e) { ctx.toast("Save failed: " + String(e), true); }
+          ts._tuneRev = (ts._tuneRev || 0) + 1;
+          if (ctx.actions.modelRefresh) await ctx.actions.modelRefresh();
+        } catch (e) {
+          ctx.toast("Save failed: height not stored", true);
+        } finally {
+          tuneRelease(ts);
+        }
       });
       zRow.appendChild(zLbl); zRow.appendChild(zInp); zRow.appendChild(zBtn);
       infoCard.appendChild(zRow);
@@ -2768,30 +2974,63 @@ function _tuneTab(ctx, el, cs, calData) {
     removeBtn.textContent = "Remove from floor";
     removeBtn.title = "Remove this receiver from " + _floorName;
     removeBtn.addEventListener("click", async () => {
-      const d = ts.draftReceivers[_selMapId] || [];
-      const _removed = d.find(r => r.id === _selRxId);
-      ts.draftReceivers[_selMapId] = d.filter(r => r.id !== _selRxId);
-      ts.dirtyMaps[_selMapId] = true;
-      ts.selectedRx = null;
-      // Save immediately
-      const origMap = maps_list.find(m => m.id === _selMapId);
-      if (origMap) {
-        try {
-          // Drop it from the fabric FIRST. A batch save only writes the
-          // entries it carries — it never deletes — and the re-derive that
-          // follows re-injects any fabric scanner claiming this map, so
-          // saving the shortened draft alone would put it straight back.
-          const _rmSrc = (_removed && (_removed.source || _removed.id)) || "";
-          if (_rmSrc) {
-            await ctx.actions.callWS({ type: "padspan_ha/fabric_scanner_remove", source: _rmSrc });
-          }
-          ts.dirtyMaps = {};
-          ts._mapsStamp = null;
-          ctx.toast("Receiver removed");
-          await ctx.actions.mapsRefresh();
-        } catch (e) {
-          ctx.toast("Remove failed: " + String(e), true);
+      // The lock is acquired BEFORE any mutation: a busy session returns
+      // with everything unchanged. The request is pessimistic — the draft
+      // row is removed only after the backend acknowledges.
+      if (!tuneTryAcquire(ts)) {
+        ctx.toast("A save is in progress — try again in a moment", true);
+        return;
+      }
+      try {
+        const d = ts.draftReceivers[_selMapId] || [];
+        const _removed = d.find(r => r.id === _selRxId);
+        const _rmSrc = (_removed && (_removed.source || _removed.id)) || "";
+        if (!_rmSrc) return;
+        const origMap = maps_list.find(m => m.id === _selMapId);
+        if (!origMap) {
+          ctx.toast("Remove failed: map not found", true);
+          return;
         }
+        // Drop it from the backend FIRST. NOTE (pre-existing backend
+        // limitation, out of scope here): fabric_scanner_remove deletes
+        // the model's scanner metadata only — the fabric spatial entry
+        // persists server-side. This callback therefore claims no more
+        // than the metadata removal plus the local draft cleanup below.
+        let _rres = null;
+        try {
+          _rres = await ctx.actions.callWS({
+            type: "padspan_ha/fabric_scanner_remove", source: _rmSrc });
+        } catch (e) {
+          _rres = { ok: false };
+        }
+        if (_rres && _rres.ok === false) {
+          ctx.toast("Remove failed: receiver not removed", true);
+          return;
+        }
+        // After ack: targeted cleanup ONLY. Unrelated edits — including
+        // other rows on this SAME map — keep their coords, baselines and
+        // dirty flags exactly as they were.
+        ts.draftReceivers[_selMapId] = d.filter(r => r.id !== _selRxId);
+        if (ts.editBaseline && ts.editBaseline[_selMapId]) {
+          delete ts.editBaseline[_selMapId][_rmSrc];
+        }
+        ts._tuneRev = (ts._tuneRev || 0) + 1;
+        ts.selectedRx = null;
+        // Publish the removal locally, then refresh: a swallowed refresh
+        // failure must not resurrect the row in the local model.
+        try {
+          const _mdl = ctx.state.model || (ctx.state.model = {});
+          if (_mdl.scanners && typeof _mdl.scanners === "object") {
+            delete _mdl.scanners[_rmSrc];
+          }
+        } catch (_e) { /* publication is best-effort */ }
+        ctx.toast("Receiver removed");
+        await ctx.actions.mapsRefresh();
+        if (ctx.actions.modelRefresh) await ctx.actions.modelRefresh();
+      } catch (e) {
+        ctx.toast("Remove failed: " + String(e), true);
+      } finally {
+        tuneRelease(ts);
       }
     });
     infoCard.appendChild(removeBtn);
@@ -2984,6 +3223,7 @@ function _tuneTab(ctx, el, cs, calData) {
               ts.pendingPlace = null;
               // 4. Call radioResetQuiet — WS only, no re-render
               const res = await ctx.actions.radioResetQuiet(src);
+              ts._tuneRev = (ts._tuneRev || 0) + 1;
               const sm = res?.summary || {};
               const parts = [];
               if (removedMaps.length) parts.push(`${removedMaps.length} map(s)`);

--- a/custom_components/padspan_ha/www/padspan-ha/views/tune_save_plan.js
+++ b/custom_components/padspan_ha/www/padspan-ha/views/tune_save_plan.js
@@ -1,0 +1,298 @@
+// Tune receiver save plan — pure, testable, no DOM.
+//
+// The Tune tab edits map-fraction drafts; the fabric holds authoritative
+// metres. This module is the narrow bridge between the two. It takes no
+// ctx, touches no DOM, and posts nothing — the view calls it, then issues
+// the resulting payloads.
+//
+// EDIT INTENT = DIFFERENCE FROM BASELINE. Every draft row carries the
+// coordinates it had when last synced (seeded, reconciled, or saved):
+// ts.editBaseline[mapId][source] = {x, y}. A row is an edit candidate
+// only when its current fractions differ bitwise from its baseline, or
+// when its pin is missing from the fabric entirely (placed-but-never-
+// saved). A stale pin nobody touched compares equal to its baseline and
+// NEVER posts, however far it lies from the fabric — disagreement with
+// the fabric is not an edit. Reconcile and save both advance the
+// baseline, so production-rounded fractions can never drift past the
+// save and post spuriously.
+//
+// Canonical gates mirror the backend exactly (fabric_truth.
+// placement_is_readable): scales present and POSITIVE with >=1mm reach on
+// both axes, forward probe finite, inverse finite. Conversion functions
+// are INJECTED by the caller (calibration.js imports them from
+// stack_transform.js). This module must not import photo-adjacent modules
+// itself: the photo-divorce guard certifies every non-editor view
+// photo-free. The injected functions are the canonical shared
+// implementation — never a copy.
+let _fracToM = null;
+let _mToFrac = null;
+export function tuneSavePlanInit(conv) {
+  _fracToM = conv.mapFracToMetres;
+  _mToFrac = conv.metresToMapFrac;
+}
+function mapFracToMetres(tf, fx, fy) {
+  if (typeof _fracToM !== "function") return null;
+  return _fracToM(tf, fx, fy);
+}
+function metresToMapFrac(tf, xm, ym) {
+  if (typeof _mToFrac !== "function") return null;
+  return _mToFrac(tf, xm, ym);
+}
+
+// Same-session mutual exclusion for fabric writers (position save, height
+// save, removal). Single-threaded JS: a boolean is sufficient. Acquire
+// BEFORE the first request; release unconditionally (finally). A caller
+// that finds it held must NOT post — toast busy and return, changing
+// nothing. There is deliberately no queue: a save completes in ~100ms and
+// a queued height would land on a baseline it never saw.
+export function tuneTryAcquire(ts) {
+  if (!ts) return false;
+  if (ts._tuneBusy) return false;
+  ts._tuneBusy = true;
+  return true;
+}
+export function tuneRelease(ts) {
+  if (ts) ts._tuneBusy = false;
+}
+
+// A placement the backend can actually convert through: scales present
+// and POSITIVE (backend requires sx >= 1e-3 and sy*|cos σ| >= 1e-3 — a
+// negative scale is unreadable, not mirrored), forward probe finite and
+// the inverse finite (singular scale / quarter-turn lean refuse).
+export function tunePlacementReadable(tf) {
+  if (!tf || typeof tf !== "object") return false;
+  const sx = Number(tf.scale_x_m);
+  const sy = Number(tf.scale_y_m);
+  if (!(sx >= 1e-3)) return false;
+  const sig = Number(tf.shear_rad ?? 0);
+  if (!Number.isFinite(sig)) return false;
+  if (!(sy * Math.abs(Math.cos(sig)) >= 1e-3)) return false;
+  const rot = Number(tf.rotation_rad ?? 0);
+  if (!Number.isFinite(rot)) return false;
+  const probe = mapFracToMetres(tf, 1.0, 1.0);
+  if (!probe || !Number.isFinite(probe[0]) || !Number.isFinite(probe[1])) return false;
+  const back = metresToMapFrac(tf, probe[0], probe[1]);
+  if (!back || !Number.isFinite(back[0]) || !Number.isFinite(back[1])) return false;
+  return true;
+}
+
+function _finiteNum(v) {
+  if (typeof v === "number") return Number.isFinite(v) ? v : null;
+  if (typeof v === "string" && v.trim() !== "") {
+    const n = Number(v);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+}
+
+// Seed drafts from stored map pins. PURE construction — no baselines, no
+// reconcile. The sync routine below owns both.
+export function tuneSeedDrafts(mapsList) {
+  const drafts = {};
+  for (const m of mapsList || []) {
+    drafts[m.id] = (m.receivers || []).map(r => ({
+      id: r.id || r.source || ("rx_" + Math.random().toString(16).slice(2, 10)),
+      label: r.label || "", x: Number(r.x || 0), y: Number(r.y || 0),
+      room: r.room || "", source: r.source || "",
+    }));
+  }
+  return drafts;
+}
+
+export function tuneMapsStamp(mapsList) {
+  return (mapsList || []).map(m =>
+    `${m.id}:${m.updated || ""}:${(m.receivers || []).length}`).join("|");
+}
+
+// Baseline snapshot of one map's draft: addressed sources to the exact
+// fractions last synced (seeded, reconciled, or acknowledged on save).
+// Exported so the save handler advances exactly the acknowledged rows.
+export function tuneSnapBaseline(draftRows) {
+  const base = {};
+  for (const r of draftRows || []) {
+    const src = (r && r.source) || "";
+    // Unaddressable rows cannot post; they carry no baseline either.
+    if (!src || base[src]) continue;
+    base[src] = { x: r.x, y: r.y };
+  }
+  return base;
+}
+function _snapBaseline(draftRows) {
+  return tuneSnapBaseline(draftRows);
+}
+
+// Single authoritative draft-sync, shared by initial render and Reset.
+//   - empty drafts → seed everything, baseline = seeded coords, then
+//     reconcile clean maps (baseline follows reconciled coords);
+//   - maps metadata changed → reseed CLEAN maps only (dirty drafts keep
+//     both their coords AND their baselines), drop dead maps;
+//   - model data changed → reconcile clean maps (a model arriving after
+//     the initial map-seeded render is the normal first-paint order).
+// Reconcile failures leave map as seeded with a seeded baseline; dirty
+// maps are never reseeded and never reconciled here.
+export function tuneSyncTuneDrafts(ts, mapsList, fabricPositions, transforms) {
+  if (!ts) return;
+  const fab = fabricPositions || {};
+  const tfs = transforms || {};
+  ts.draftReceivers = ts.draftReceivers || {};
+  ts.dirtyMaps = ts.dirtyMaps || {};
+  ts.editBaseline = ts.editBaseline || {};
+  const stamp = tuneMapsStamp(mapsList);
+  const modelStamp = JSON.stringify(fab) + "|" + JSON.stringify(tfs);
+  const fresh = Object.keys(ts.draftReceivers).length === 0;
+  if (fresh) {
+    ts.draftReceivers = tuneSeedDrafts(mapsList);
+    for (const m of mapsList || []) {
+      ts.editBaseline[m.id] = _snapBaseline(ts.draftReceivers[m.id]);
+    }
+  } else if (stamp !== ts._mapsStamp) {
+    for (const m of mapsList || []) {
+      if (ts.dirtyMaps[m.id]) continue;
+      ts.draftReceivers[m.id] = tuneSeedDrafts([m])[m.id];
+      ts.editBaseline[m.id] = _snapBaseline(ts.draftReceivers[m.id]);
+    }
+    for (const id of Object.keys(ts.draftReceivers)) {
+      if (!(mapsList || []).some(m => m.id === id)) {
+        delete ts.draftReceivers[id];
+        delete ts.editBaseline[id];
+      }
+    }
+  }
+  if (fresh || stamp !== ts._mapsStamp || modelStamp !== ts._modelStamp) {
+    for (const m of mapsList || []) {
+      if (ts.dirtyMaps[m.id]) continue;
+      try {
+        const next = tuneReconcileDraft(
+          m, ts.draftReceivers[m.id] || [], fab, tfs, false);
+        if (next) {
+          ts.draftReceivers[m.id] = next;
+          ts.editBaseline[m.id] = _snapBaseline(next);
+        }
+      } catch (e) { /* best-effort; seeded drafts stay */ }
+    }
+  }
+  ts._mapsStamp = stamp;
+  ts._modelStamp = modelStamp;
+}
+
+// Diff one map's draft for the save. A row is a candidate ONLY when its
+// fractions differ bitwise from its baseline (an actual drag/place this
+// session) or — with includeMissing — its pin is absent from the fabric
+// (placed-but-never-saved). Untouched rows never post, however stale.
+// Returns { writes: [{source,x_m,y_m,floor_id,z_m?}], skipped: [""],
+// invalid: [source…], refused: bool }.
+//   invalid — addressed rows (have a source) whose coords will not coerce
+//     to finite numbers: failed pending work, NOT a silent skip.
+// z_m carries the stored height for existing entries (preserved, never
+// restated from the draft — drafts have no z); new entries omit z_m so
+// the backend default applies.
+export function tuneDiffMapDraft(mapObj, draftRows, fabricPositions, transforms,
+    baselineMap, includeMissing) {
+  const tf = transforms ? transforms[mapObj.id] : null;
+  if (!tunePlacementReadable(tf)) return { writes: [], skipped: [], invalid: [], refused: true };
+  const writes = [];
+  const skipped = [];
+  const invalid = [];
+  const seen = new Set();
+  const fab = fabricPositions || {};
+  const base = baselineMap || {};
+  for (const r of draftRows || []) {
+    const src = (r && r.source) || "";
+    if (!src) { skipped.push(src); continue; }
+    if (seen.has(src)) continue;
+    seen.add(src);
+    const b = base[src];
+    const changed = !b || b.x !== r.x || b.y !== r.y;
+    const missing = includeMissing && !fab[src];
+    if (!changed && !missing) continue;
+    const fx = _finiteNum(r.x), fy = _finiteNum(r.y);
+    if (fx === null || fy === null) { invalid.push(src); continue; }
+    const m = mapFracToMetres(tf, fx, fy);
+    if (!m || !Number.isFinite(m[0]) || !Number.isFinite(m[1])) {
+      return { writes: [], skipped, invalid, refused: true };
+    }
+    const prev = fab[src];
+    const w = { source: src, x_m: Math.round(m[0] * 1000) / 1000,
+      y_m: Math.round(m[1] * 1000) / 1000, floor_id: mapObj.floor_id || "main" };
+    if (prev && Number.isFinite(Number(prev.z_m))) w.z_m = Number(prev.z_m);
+    writes.push(w);
+  }
+  return { writes, skipped, invalid, refused: false };
+}
+
+// Eligible missing-fabric pins across ALL maps: draft receivers with a
+// source, valid coords, absent from the fabric, on a readable placement.
+// Returns EVERY occurrence [{mapId, source}] — dedup happens AFTER
+// conflict detection, so the same missing source on two differently-
+// placed maps is refused on both instead of silently writing the first.
+export function tuneMissingFabricPins(mapsList, draftReceivers, fabricPositions, transforms) {
+  const out = [];
+  const fab = fabricPositions || {};
+  for (const m of mapsList || []) {
+    if (!tunePlacementReadable(transforms ? transforms[m.id] : null)) continue;
+    for (const r of (draftReceivers || {})[m.id] || []) {
+      const src = (r && r.source) || "";
+      if (!src || fab[src]) continue;
+      if (_finiteNum(r.x) === null || _finiteNum(r.y) === null) continue;
+      out.push({ mapId: m.id, source: src });
+    }
+  }
+  return out;
+}
+
+// Conflicting writes for one source (different metres or floor beyond
+// tolerance). Returns [source…]; the save refuses those sources everywhere
+// rather than letting last-write-win silently.
+export function tuneConflictingSources(perMapWrites, tolM) {
+  const tol = (tolM !== undefined) ? tolM : 0.0005;
+  const bySrc = new Map();
+  const bad = [];
+  for (const w of perMapWrites || []) {
+    const prev = bySrc.get(w.source);
+    if (!prev) { bySrc.set(w.source, w); continue; }
+    const dx = Math.abs(prev.x_m - w.x_m), dy = Math.abs(prev.y_m - w.y_m);
+    const sameFloor = String(prev.floor_id) === String(w.floor_id);
+    if ((dx > tol || dy > tol || !sameFloor) && !bad.includes(w.source)) bad.push(w.source);
+  }
+  return bad;
+}
+
+// Reconcile a CLEAN draft map from authoritative fabric: project every
+// fabric entry inside this map's footprint back to fractions, preserving
+// draft metadata (id/label/room) by source match. Dirty maps are NEVER
+// touched here — unsaved user edits (positions AND failed writes) survive.
+// Fractions keep FULL inverse precision (no rounding): the baseline snaps
+// the same values, so no drift can ever read as an edit.
+// Returns the reconciled draft array, or null when the map must be left
+// alone (dirty, or unreadable placement).
+export function tuneReconcileDraft(mapObj, draftRows, fabricPositions, transforms, isDirty) {
+  if (isDirty) return null;
+  const tf = transforms ? transforms[mapObj.id] : null;
+  if (!tunePlacementReadable(tf)) return null;
+  const bySrc = new Map();
+  for (const r of draftRows || []) {
+    const src = (r && r.source) || "";
+    if (src && !bySrc.has(src)) bySrc.set(src, r);
+  }
+  const next = [];
+  for (const [src, prev] of Object.entries(fabricPositions || {})) {
+    if (typeof prev !== "object" || !prev) continue;
+    if (!Number.isFinite(Number(prev.x_m)) || !Number.isFinite(Number(prev.y_m))) continue;
+    if (String(prev.floor_id || "main") !== String(mapObj.floor_id || "main")) continue;
+    const f = metresToMapFrac(tf, Number(prev.x_m), Number(prev.y_m));
+    if (!f || !Number.isFinite(f[0]) || !Number.isFinite(f[1])) continue;
+    if (f[0] < -0.05 || f[0] > 1.05 || f[1] < -0.05 || f[1] > 1.05) continue;
+    const old = bySrc.get(src) || {};
+    next.push({ id: old.id || src, label: old.label || src,
+      x: f[0], y: f[1], room: old.room || "", source: src });
+    bySrc.delete(src);
+  }
+  // Draft rows with no fabric entry (failed writes, unconvertible maps,
+  // brand-new placements) stay exactly as the user left them.
+  for (const r of draftRows || []) {
+    const src = (r && r.source) || "";
+    if (src && (fabricPositions || {})[src]) continue;
+    next.push(r);
+  }
+  return next;
+}

--- a/tests/js/tune_save_fabric.mjs
+++ b/tests/js/tune_save_fabric.mjs
@@ -1,0 +1,688 @@
+// Tune Save -> fabric lifecycle harness (R4/R5).
+//
+// Executes the SHIPPED registered callbacks from calibration.js — the Tune
+// Save handler, the Height (Save Z) handler, the Remove-from-floor handler
+// and the Reset handler — against a stub ctx with a faithful backend
+// model:
+//
+//   backend.spatial  scanner_positions_m (x/y/z/floor per source)
+//   backend.meta     model scanners metadata (what fabric_scanner_remove
+//                    actually deletes — the spatial entry PERSISTS,
+//                    modelling the real backend, see finding 4)
+//
+// modelRefresh publishes backend.spatial into ctx.state.model (or swallows
+// the update on demand, modelling panel.js error swallowing); mapsRefresh
+// is counted. Deferred requests let flows interleave a save with a drag,
+// a height press, or a refresh the way the live tab does.
+//
+// Single-save scenarios run: real tuneSyncTuneDrafts init -> UI-faithful
+// draft mutations -> Save -> refreshes -> post-save sync (as a rerender).
+// Flow scenarios (flow_*) run bespoke multi-step callback sequences and
+// report journals.
+//
+// Run: node tests/js/tune_save_fabric.mjs <views dir> <scenario>
+// Prints one JSON line.
+import fs from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const VIEWS = process.argv[2];
+const SCENARIO = process.argv[3] || "moved";
+const SRC = fs.readFileSync(join(VIEWS, "calibration.js"), "utf8");
+
+function extractHandler(headMark, windowSize, tailMark) {
+  const HEAD = headMark;
+  let h = SRC.indexOf(HEAD);
+  while (h >= 0) {
+    if (SRC.slice(h, h + windowSize).includes(tailMark)) break;
+    h = SRC.indexOf(HEAD, h + 1);
+  }
+  if (h < 0) throw new Error("handler not found: " + headMark);
+  return { h };
+}
+
+// Tune Save handler: the saveBtn listener whose body reads dirtyMaps.
+const SAVE_HEAD = '  saveBtn.addEventListener("click", async () => {';
+const SAVE_MARK = "const dirtyIds = Object.keys(ts.dirtyMaps)";
+let hStart = SRC.indexOf(SAVE_HEAD);
+while (hStart >= 0) {
+  if (SRC.slice(hStart, hStart + 2600).includes(SAVE_MARK)) break;
+  hStart = SRC.indexOf(SAVE_HEAD, hStart + 1);
+}
+if (hStart < 0) throw new Error("Tune Save handler body not found");
+const SAVE_TAIL = "  });\n\n  // Reset button";
+const saveTailIdx = SRC.indexOf(SAVE_TAIL, hStart);
+if (saveTailIdx < 0) throw new Error("Reset-button anchor moved; harness needs updating");
+const SAVE_HANDLER = SRC.slice(hStart, saveTailIdx + "  });".length);
+
+// Height handler: the zBtn listener inside the info panel.
+const Z_HEAD = '      zBtn.addEventListener("click", async () => {';
+const Z_TAIL = "      });\n      zRow.appendChild(zLbl);";
+const zStart = SRC.indexOf(Z_HEAD);
+if (zStart < 0) throw new Error("Height handler not found");
+const zTailIdx = SRC.indexOf(Z_TAIL, zStart);
+if (zTailIdx < 0) throw new Error("Height handler tail moved; harness needs updating");
+const HEIGHT_HANDLER = SRC.slice(zStart, zTailIdx + "      });".length);
+
+// Removal handler: the removeBtn listener ("Remove from floor").
+const R_HEAD = '    removeBtn.addEventListener("click", async () => {';
+const R_TAIL = "    });\n    infoCard.appendChild(removeBtn);";
+const rStart = SRC.indexOf(R_HEAD);
+if (rStart < 0) throw new Error("Removal handler not found");
+const rTailIdx = SRC.indexOf(R_TAIL, rStart);
+if (rTailIdx < 0) throw new Error("Removal handler tail moved; harness needs updating");
+const REMOVE_HANDLER = SRC.slice(rStart, rTailIdx + "    });".length);
+
+// Reset handler: up to ctrlRow.appendChild(saveBtn).
+const RST_HEAD = '  resetBtn.addEventListener("click", () => {';
+const RST_TAIL = "  });\n\n  ctrlRow.appendChild(saveBtn);";
+const rstStart = SRC.indexOf(RST_HEAD);
+// NOTE: several resetBtn listeners exist (other tabs); take the one in the
+// Tune tab — the one whose body touches ts.draftReceivers.
+let rst = rstStart;
+while (rst >= 0) {
+  const tail = SRC.indexOf(RST_TAIL, rst);
+  if (tail > rst && SRC.slice(rst, tail).includes("ts.draftReceivers = {};")) break;
+  rst = SRC.indexOf(RST_HEAD, rst + 1);
+}
+if (rst < 0) throw new Error("Tune Reset handler not found");
+const rstTailIdx = SRC.indexOf(RST_TAIL, rst);
+const RESET_HANDLER = SRC.slice(rst, rstTailIdx + "  });".length);
+
+const EE1 = "aa:bb:cc:dd:ee:01";
+const GH = "google_home_3e759f07-new";
+const GHU = "google_home_6f47324e-new";
+
+function baseMaps() {
+  return [
+    { id: "mA", name: "Lower", floor_id: "downstairs", updated: "t0",
+      receivers: [
+        { id: "r1", label: "RX1", x: 0.30, y: 0.30, room: "A", source: EE1 },
+      ] },
+    { id: "mB", name: "Upper", floor_id: "upper", updated: "t0", receivers: [] },
+  ];
+}
+function baseModel() {
+  return {
+    floors: [{ id: "downstairs", name: "Down" }, { id: "upper", name: "Up" }],
+    settings: {},
+    map_transforms: {
+      mA: { origin_x_m: 1.3, origin_y_m: -0.98, scale_x_m: 18.01,
+            scale_y_m: 12.04, rotation_rad: -0.015, shear_rad: 0.008,
+            floor_id: "downstairs" },
+    },
+    scanner_positions_m: {
+      [EE1]: { x_m: 5.0, y_m: 5.0, z_m: 1.2, floor_id: "downstairs" },
+      "aa:bb:cc:dd:ee:02": { x_m: 9.0, y_m: 9.0, z_m: 2.4, floor_id: "upper" },
+    },
+  };
+}
+function scenario(name, maps_list, model) {
+  const drag = (ts, mid, src, x, y) => {
+    const r = ts.draftReceivers[mid].find(q => q.source === src);
+    r.x = x; r.y = y;
+    ts.dirtyMaps[mid] = true;
+    ts._tuneRev = (ts._tuneRev || 0) + 1;
+  };
+  const place = (ts, mid, row) => {
+    ts.draftReceivers[mid].push(row);
+    ts.dirtyMaps[mid] = true;
+    ts._tuneRev = (ts._tuneRev || 0) + 1;
+  };
+  switch (name) {
+    case "moved":
+      return { opts: {}, flow: "save", mutate(ts) {
+        drag(ts, "mA", EE1, 0.10, 0.10);
+        place(ts, "mA", { id: "rx_new", label: "Spare Mini", x: 0.0289,
+          y: 0.0485, room: "B", source: GH });
+      } };
+    case "nodrag":
+      return { opts: {}, flow: "save", mutate(ts) {} };
+    case "missingfabric":
+      maps_list.find(m => m.id === "mA").receivers.push(
+        { id: "rx_miss", label: "Spare Mini", x: 0.0289, y: 0.0485,
+          room: "B", source: GH });
+      return { opts: {}, flow: "save", mutate(ts) {} };
+    case "stale":
+      delete model.map_transforms.mA;
+      return { opts: {}, flow: "save", mutate(ts) {
+        model.map_transforms.mA = { origin_x_m: 1.3, origin_y_m: -0.98,
+          scale_x_m: 18.01, scale_y_m: 12.04, rotation_rad: -0.015,
+          shear_rad: 0.008, floor_id: "downstairs" };
+        place(ts, "mA", { id: "rx_new", label: "Spare Mini", x: 0.0289,
+          y: 0.0485, room: "B", source: GH });
+      } };
+    case "untouched":
+      return { opts: {}, flow: "save", mutate(ts) {
+        place(ts, "mA", { id: "rx_new", label: "Spare Mini", x: 0.0289,
+          y: 0.0485, room: "B", source: GH });
+      } };
+    case "unmeasured":
+      maps_list.find(m => m.id === "mB").receivers.push(
+        { id: "rx_u", label: "New", x: 0.5, y: 0.5, room: "", source: GHU });
+      return { opts: {}, flow: "save", mutate(ts) {
+        ts.draftReceivers.mB.push({ id: "rx_u", label: "New", x: 0.5,
+          y: 0.5, room: "", source: GHU });
+        ts.dirtyMaps.mB = true;
+        ts._tuneRev = (ts._tuneRev || 0) + 1;
+      } };
+    case "partial":
+      maps_list.find(m => m.id === "mB").receivers.push(
+        { id: "rx_u", label: "New", x: 0.5, y: 0.5, room: "", source: GHU });
+      return { opts: {}, flow: "save", mutate(ts) {
+        drag(ts, "mA", EE1, 0.10, 0.10);
+        ts.draftReceivers.mB.push({ id: "rx_u", label: "New", x: 0.5,
+          y: 0.5, room: "", source: GHU });
+        ts.dirtyMaps.mB = true;
+        ts._tuneRev = (ts._tuneRev || 0) + 1;
+      } };
+    case "conflict":
+      model.map_transforms.mB = { origin_x_m: 0, origin_y_m: 0,
+        scale_x_m: 10, scale_y_m: 10, rotation_rad: 0, shear_rad: 0,
+        floor_id: "upper" };
+      maps_list.find(m => m.id === "mB").receivers.push(
+        { id: "r1b", label: "RX1", x: 0.9, y: 0.9, room: "C", source: EE1 });
+      return { opts: {}, flow: "save", mutate(ts) {
+        drag(ts, "mA", EE1, 0.10, 0.10);
+        if (!ts.draftReceivers.mB.some(q => q.source === EE1)) {
+          ts.draftReceivers.mB.push({ id: "r1b", label: "RX1", x: 0.9,
+            y: 0.9, room: "C", source: EE1 });
+        }
+        const r = ts.draftReceivers.mB.find(q => q.source === EE1);
+        r.x = 0.91; r.y = 0.91;
+        ts.dirtyMaps.mB = true;
+        ts._tuneRev = (ts._tuneRev || 0) + 1;
+      } };
+    case "missingconflict":
+      model.map_transforms.mB = { origin_x_m: 0, origin_y_m: 0,
+        scale_x_m: 10, scale_y_m: 10, rotation_rad: 0, shear_rad: 0,
+        floor_id: "upper" };
+      maps_list.find(m => m.id === "mA").receivers.push(
+        { id: "rx_dup", label: "Dup", x: 0.10, y: 0.10, room: "A", source: GH });
+      maps_list.find(m => m.id === "mB").receivers.push(
+        { id: "rx_dup2", label: "Dup", x: 0.90, y: 0.90, room: "C", source: GH });
+      return { opts: {}, flow: "save" };
+    case "missingmap":
+      return { opts: {}, flow: "save", mutate(ts) {
+        ts.draftReceivers.mGhost = [{ id: "rx_g", label: "Ghost", x: 0.5,
+          y: 0.5, room: "", source: "aa:bb:cc:dd:ee:09" }];
+        ts.dirtyMaps.mGhost = true;
+        ts._tuneRev = (ts._tuneRev || 0) + 1;
+      } };
+    case "singular":
+      model.map_transforms.mA = { origin_x_m: 0, origin_y_m: 0,
+        scale_x_m: 0, scale_y_m: 12.04, rotation_rad: 0, shear_rad: 0,
+        floor_id: "downstairs" };
+      return { opts: {}, flow: "save", mutate(ts) {
+        drag(ts, "mA", EE1, 0.10, 0.10);
+      } };
+    case "negscale":
+      model.map_transforms.mA = { origin_x_m: 0, origin_y_m: 0,
+        scale_x_m: -18.01, scale_y_m: 12.04, rotation_rad: 0, shear_rad: 0,
+        floor_id: "downstairs" };
+      return { opts: {}, flow: "save", mutate(ts) {
+        drag(ts, "mA", EE1, 0.10, 0.10);
+      } };
+    case "invalid":
+      return { opts: {}, flow: "save", mutate(ts) {
+        const r = ts.draftReceivers.mA.find(q => q.source === EE1);
+        r.x = "not-a-number";
+        ts.dirtyMaps.mA = true;
+        ts._tuneRev = (ts._tuneRev || 0) + 1;
+      } };
+    case "reject":
+      return { opts: { rejectSource: EE1 }, flow: "save", mutate(ts) {
+        drag(ts, "mA", EE1, 0.10, 0.10);
+      } };
+    case "throw":
+      return { opts: { throwSource: GH }, flow: "save", mutate(ts) {
+        drag(ts, "mA", EE1, 0.10, 0.10);
+        place(ts, "mA", { id: "rx_new", label: "Spare Mini", x: 0.0289,
+          y: 0.0485, room: "B", source: GH });
+      } };
+    case "concurrent":
+      return { opts: { concurrentDrag: true }, flow: "save", mutate(ts) {
+        drag(ts, "mA", EE1, 0.10, 0.10);
+      } };
+    case "dedupfail":
+      model.map_transforms.mB = { origin_x_m: 1.3, origin_y_m: -0.98,
+        scale_x_m: 18.01, scale_y_m: 12.04, rotation_rad: -0.015,
+        shear_rad: 0.008, floor_id: "downstairs" };
+      maps_list.find(m => m.id === "mB").floor_id = "downstairs";
+      return { opts: { rejectSource: GH }, flow: "save", mutate(ts) {
+        ts.draftReceivers.mA.push({ id: "rx_dup", label: "Dup", x: 0.10,
+          y: 0.10, room: "A", source: GH });
+        ts.dirtyMaps.mA = true;
+        ts.draftReceivers.mB.push({ id: "rx_dup2", label: "Dup", x: 0.10,
+          y: 0.10, room: "C", source: GH });
+        ts.dirtyMaps.mB = true;
+        ts._tuneRev = (ts._tuneRev || 0) + 1;
+      } };
+    // Flow scenarios run bespoke callback sequences (see part 3).
+    case "flow_saveA_retryB_reset":
+    case "flow_reset_dirty":
+    case "flow_height_blocked":
+    case "flow_height_refresh_fail":
+    case "flow_save_refresh_fail":
+    case "flow_removal_busy":
+    case "flow_removal_reject":
+    case "flow_removal_ok":
+      return { opts: {}, flow: name };
+    default:
+      throw new Error("unknown scenario " + name);
+  }
+}
+const maps_list = baseMaps();
+const model = baseModel();
+const sc = scenario(SCENARIO, maps_list, model);
+const FLOW = sc.flow && sc.flow.startsWith("flow_");
+
+const planMod = await import(pathToFileURL(join(VIEWS, "tune_save_plan.js")).href);
+const stackMod = await import(pathToFileURL(join(VIEWS, "stack_transform.js")).href);
+planMod.tuneSavePlanInit({ mapFracToMetres: stackMod.mapFracToMetres,
+  metresToMapFrac: stackMod.metresToMapFrac });
+const P = planMod;
+
+const calls = [];
+const toasts = [];
+const journal = [];
+const J = (ev, data) => journal.push({ ev, ...(data || {}) });
+
+const backend = {
+  spatial: JSON.parse(JSON.stringify(model.scanner_positions_m)),
+  meta: { scanners: Object.fromEntries(
+    Object.keys(model.scanner_positions_m).map(s => [s, { room: "r" }])) },
+};
+let refreshCount = 0;
+let swallowRefresh = false;
+const deferred = [];
+const flush = (n) => new Promise(res => setTimeout(res, n || 0));
+
+const ts = { draftReceivers: {}, dirtyMaps: {},
+             selectedRx: null, _tuneRev: 0 };
+P.tuneSyncTuneDrafts(ts, maps_list, model.scanner_positions_m,
+  model.map_transforms);
+if (!FLOW && sc.mutate) sc.mutate(ts);
+
+const mkBtn = () => {
+  const b = { disabled: false, textContent: "",
+    classList: { add() {}, remove() {} }, style: {}, _fn: null,
+    addEventListener(ev, fn) { if (ev === "click") b._fn = fn; } };
+  return b;
+};
+const saveBtn = mkBtn();
+const statusLbl = { textContent: "", style: {} };
+
+const ctx = {
+  state: { model, maps: { list: maps_list } },
+  actions: {
+    callWS: async (p) => {
+      calls.push(JSON.parse(JSON.stringify(p)));
+      if (p.type === "padspan_ha/fabric_scanner_position_set") {
+        if (sc.opts.rejectSource === p.source) return { ok: false };
+        if (sc.opts.throwSource === p.source) throw new Error("boom");
+        if (sc.opts.deferPositions) {
+          J("deferred-held", { source: p.source });
+          await new Promise((resolve, reject) =>
+            deferred.push({ resolve, reject, p }));
+        }
+        // Backend default: omitted z_m stores 2.4 (model_store path).
+        backend.spatial[p.source] = { x_m: p.x_m, y_m: p.y_m,
+          z_m: p.z_m !== undefined ? p.z_m :
+            ((backend.spatial[p.source] || {}).z_m !== undefined ?
+              backend.spatial[p.source].z_m : 2.4),
+          floor_id: p.floor_id };
+        if (sc.opts.concurrentDrag) {
+          sc.opts.concurrentDrag = false;
+          const r = ts.draftReceivers.mA.find(q => q.source === EE1);
+          r.x = 0.77; r.y = 0.77;
+          ts.dirtyMaps.mA = true;
+          ts._tuneRev = (ts._tuneRev || 0) + 1;
+        }
+        return { ok: true };
+      }
+      if (p.type === "padspan_ha/fabric_scanner_z_set") {
+        // Backend rounds to 2dp within 0..100 (model_store z path).
+        const zv = Math.round(Math.max(0, Math.min(100, Number(p.z_m))) * 100) / 100;
+        backend.spatial[p.source] = { ...(backend.spatial[p.source] || {}), z_m: zv };
+        return { ok: true };
+      }
+      if (p.type === "padspan_ha/fabric_scanner_remove") {
+        if (sc.opts.rejectRemove) return { ok: false };
+        if (sc.opts.throwRemove) throw new Error("boom-remove");
+        if (sc.opts.deferRemove) {
+          await new Promise((resolve, reject) =>
+            deferred.push({ resolve, reject, p }));
+        }
+        delete backend.meta.scanners[p.source];
+        return { ok: true };
+      }
+      return { ok: true };
+    },
+    mapsRefresh: async () => { refreshCount++; },
+    modelRefresh: async () => {
+      refreshCount++;
+      if (swallowRefresh) return;
+      ctx.state.model = { ...ctx.state.model,
+        scanner_positions_m: JSON.parse(JSON.stringify(backend.spatial)) };
+    },
+  },
+  toast: (m) => { toasts.push(String(m)); },
+};
+
+const preamble =
+  "const _refreshDirtyLabel = () => {};\n" +
+  "const _refreshSVG = () => {};\n" +
+  "const _refreshInfo = () => {};\n" +
+  "const _refreshRadiosList = () => {};\n" +
+  "const _refreshPlaceBanner = () => {};\n";
+const shimUrl = pathToFileURL(join(VIEWS, "calibration.js")).href;
+function shimmed(src) {
+  return "const import_meta_url = " + JSON.stringify(shimUrl) + ";\n" +
+    src
+      .replaceAll("import.meta.url", "import_meta_url")
+      .replaceAll("new URL(import_meta_url).search", JSON.stringify(""))
+      .replaceAll("./tune_save_plan.js",
+        pathToFileURL(join(VIEWS, "tune_save_plan.js")).href);
+}
+const PLAN_NAMES = ["tuneDiffMapDraft", "tuneMissingFabricPins",
+  "tuneConflictingSources", "tuneReconcileDraft", "tuneSyncTuneDrafts",
+  "tuneSnapBaseline", "tuneTryAcquire", "tuneRelease"];
+function compileHandler(body, extraParams, extraArgs) {
+  const params = ["ts", "maps_list", "ctx", "saveBtn", "statusLbl",
+    "calls", "toasts", "refreshCount",
+    ...PLAN_NAMES, "mapFracToMetres",
+    ...(extraParams || [])];
+  const args = [ts, maps_list, ctx, saveBtn, statusLbl, calls, toasts,
+    refreshCount, P.tuneDiffMapDraft, P.tuneMissingFabricPins,
+    P.tuneConflictingSources, P.tuneReconcileDraft, P.tuneSyncTuneDrafts,
+    P.tuneSnapBaseline, P.tuneTryAcquire, P.tuneRelease,
+    stackMod.mapFracToMetres, ...(extraArgs || [])];
+  return new Function(...params, preamble + body)(...args);
+}
+function runSave() {
+  const body = shimmed(SAVE_HANDLER) +
+    "\nreturn (async () => { await saveBtn._fn();\n" +
+    "return { payloads: calls.slice(), toasts: toasts.slice(), " +
+    "dirty: JSON.parse(JSON.stringify(ts.dirtyMaps)), " +
+    "draft: JSON.parse(JSON.stringify(ts.draftReceivers)), " +
+    "baseline: JSON.parse(JSON.stringify(ts.editBaseline || {})), " +
+    "model: JSON.parse(JSON.stringify(ctx.state.model)), " +
+    "refreshCount }; })()";
+  return compileHandler(body);
+}
+function runHeight(source, label, value) {
+  const body = shimmed(HEIGHT_HANDLER) +
+    "\nreturn (async () => { await zBtn._fn(); return {}; })()";
+  const params = ["ts", "maps_list", "ctx", "rx", "zInp",
+    "calls", "toasts", "tuneTryAcquire", "tuneRelease"];
+  const zInp = { value: String(value) };
+  const fn = new Function(...params,
+    preamble +
+    "const zBtn = { _fn: null, addEventListener(ev, fn) " +
+    "{ if (ev === 'click') this._fn = fn; } };\n" +
+    "const zRow = { appendChild(){} }, zLbl = {};\n" +
+    "const infoCard = { appendChild(){} };\n" +
+    body);
+  return fn(ts, maps_list, ctx, { source, label }, zInp,
+    calls, toasts, P.tuneTryAcquire, P.tuneRelease);
+}
+function runRemove(mapId, rxId) {
+  // The extracted listener body is document-free (verified); only the
+  // button registration needs a stub.
+  const fn2 = new Function("ts", "maps_list", "ctx", "_selMapId", "_selRxId",
+    "calls", "toasts", "tuneTryAcquire", "tuneRelease",
+    preamble +
+    "const removeBtn = { _fn: null, addEventListener(ev, fn) " +
+    "{ if (ev === 'click') this._fn = fn; } };\n" +
+    "const infoCard = { appendChild(){} };\n" +
+    shimmed(REMOVE_HANDLER).replace(
+      "    removeBtn.addEventListener(\"click\", async () => {",
+      "    removeBtn.addEventListener(\"click\", async () => {") +
+    "\nreturn (async () => { await removeBtn._fn(); return {}; })()");
+  return fn2(ts, maps_list, ctx, mapId, rxId,
+    calls, toasts, P.tuneTryAcquire, P.tuneRelease);
+}
+function runReset() {
+  const sliders = () => ({ value: "0", textContent: "" });
+  const fn2 = new Function("ts", "maps_list", "ctx",
+    "calls", "toasts", "tuneSyncTuneDrafts", "tuneTryAcquire", "tuneRelease",
+    "gapSlider", "hgSlider", "focusSlider", "focusLbl",
+    "gapLbl", "hgLbl", "statusLbl",
+    preamble +
+    "const resetBtn = { _fn: null, addEventListener(ev, fn) " +
+    "{ if (ev === 'click') this._fn = fn; } };\n" +
+    "const ctrlRow = { appendChild(){} };\n" +
+    "const saveBtn = {}, dirtyLbl = { textContent: '' };\n" +
+    shimmed(RESET_HANDLER) +
+    "\nreturn (async () => { resetBtn._fn(); return {}; })()");
+  return fn2(ts, maps_list, ctx, calls, toasts, P.tuneSyncTuneDrafts,
+    P.tuneTryAcquire, P.tuneRelease,
+    sliders(), sliders(), sliders(), { textContent: "" },
+    { textContent: "" }, { textContent: "" }, statusLbl);
+}
+function posPosts(list) {
+  return list.filter(p => p.type === "padspan_ha/fabric_scanner_position_set");
+}
+function snap(o) { return JSON.parse(JSON.stringify(o)); }
+
+async function flow_saveA_retryB_reset() {
+  // (a) SaveA -> dragB -> ackA -> retry posts B -> Reset/fresh render B.
+  const r1e = ts.draftReceivers.mA.find(q => q.source === EE1);
+  r1e.x = 0.10; r1e.y = 0.10;
+  ts.dirtyMaps.mA = true;
+  ts._tuneRev = (ts._tuneRev || 0) + 1;
+  sc.opts.deferPositions = true;
+  const saveP = runSave();
+  await flush(10);
+  J("saveA-posts", { n: posPosts(calls).length });
+  r1e.x = 0.20; r1e.y = 0.20;   // B lands while A is in flight
+  ts._tuneRev = (ts._tuneRev || 0) + 1;
+  J("dragB-dirty", { dirty: snap(ts.dirtyMaps) });
+  while (deferred.length) deferred.shift().resolve();
+  sc.opts.deferPositions = false;
+  const r1 = await saveP;
+  J("saveA-done", { toasts: r1.toasts.slice(), dirty: snap(ts.dirtyMaps),
+    baseline: snap(ts.editBaseline) });
+  const nBefore = calls.length;
+  const r2 = await runSave();
+  J("retry", { posts: posPosts(calls.slice(nBefore)).map(
+    p => [p.source, p.x_m, p.y_m]),
+    toasts: r2.toasts.slice(), dirty: snap(ts.dirtyMaps) });
+  await runReset();
+  const ar = ts.draftReceivers.mA.find(q => q.source === EE1);
+  J("after-reset", { x: ar && ar.x, y: ar && ar.y,
+    dirty: snap(ts.dirtyMaps),
+    baseline: snap((ts.editBaseline.mA || {})[EE1] || null) });
+  const fresh = { draftReceivers: {}, dirtyMaps: {},
+    selectedRx: null, _tuneRev: 0 };
+  P.tuneSyncTuneDrafts(fresh, maps_list,
+    ctx.state.model.scanner_positions_m || {},
+    ctx.state.model.map_transforms || {});
+  const fr = fresh.draftReceivers.mA.find(q => q.source === EE1);
+  J("fresh-render", { x: fr && fr.x, y: fr && fr.y });
+  J("backend", { spatial: snap(backend.spatial) });
+}
+
+async function flow_reset_dirty() {
+  // (b) Dirty map with a stale pin + a fabric-only entry: Reset retains
+  // fabric coords and the fabric-only pin WITH its baseline.
+  backend.spatial["fabric-only-src"] = { x_m: 4.0, y_m: 3.0, z_m: 2.0,
+    floor_id: "downstairs" };
+  backend.meta.scanners["fabric-only-src"] = { room: "r" };
+  ctx.state.model.scanner_positions_m = snap(backend.spatial);
+  const r1e = ts.draftReceivers.mA.find(q => q.source === EE1);
+  r1e.x = 0.77; r1e.y = 0.77;   // unsaved drag (stale vs fabric)
+  ts.dirtyMaps.mA = true;
+  ts._tuneRev = (ts._tuneRev || 0) + 1;
+  await runReset();
+  const rows = ts.draftReceivers.mA;
+  J("after-reset", {
+    ee1: rows.find(q => q.source === EE1),
+    fabonly: rows.find(q => q.source === "fabric-only-src"),
+    baseline: snap(ts.editBaseline.mA || {}),
+    dirty: snap(ts.dirtyMaps) });
+}
+
+async function flow_height_blocked() {
+  // (c1) Height press with a PENDING refresh: a position Save attempted
+  // meanwhile is refused busy with zero posts; then the refresh lands and
+  // the height completes; the next position Save carries the new height.
+  const r1e = ts.draftReceivers.mA.find(q => q.source === EE1);
+  r1e.x = 0.10; r1e.y = 0.10;
+  ts.dirtyMaps.mA = true;
+  ts._tuneRev = (ts._tuneRev || 0) + 1;
+  let releaseRefresh = null;
+  const origRefresh = ctx.actions.modelRefresh;
+  ctx.actions.modelRefresh = async () => {
+    refreshCount++;
+    await new Promise(res => { releaseRefresh = res; });
+    ctx.state.model = { ...ctx.state.model,
+      scanner_positions_m: snap(backend.spatial) };
+  };
+  const heightP = runHeight(EE1, "RX1", 1.7);
+  await flush(10);
+  J("height-pending", { heightCalls: calls.filter(
+    c => c.type === "padspan_ha/fabric_scanner_z_set").length });
+  const rs = await runSave();
+  J("save-during-height", { posts: posPosts(rs.payloads).length,
+    toasts: rs.toasts.slice() });
+  releaseRefresh();
+  const hr = await heightP;
+  void hr;
+  J("height-done", { toasts: toasts.slice(),
+    localZ: (ctx.state.model.scanner_positions_m[EE1] || {}).z_m,
+    backendZ: (backend.spatial[EE1] || {}).z_m });
+  ctx.actions.modelRefresh = origRefresh;
+  const r2 = await runSave();
+  J("next-save", { posts: posPosts(r2.payloads).map(
+    p => [p.source, p.z_m]) });
+}
+
+async function flow_height_refresh_fail() {
+  // (c2) Height ack with a SWALLOWED refresh: swallowing is enabled
+  // BEFORE the height callback runs, so its own modelRefresh is the one
+  // swallowed; the acked height must survive locally anyway.
+  swallowRefresh = true;
+  await runHeight(EE1, "RX1", 1.7);
+  swallowRefresh = false;
+  J("height-acked", { toasts: toasts.slice(),
+    localZ: (ctx.state.model.scanner_positions_m[EE1] || {}).z_m });
+  J("after-swallowed-refresh", {
+    localZ: (ctx.state.model.scanner_positions_m[EE1] || {}).z_m });
+  const r1e = ts.draftReceivers.mA.find(q => q.source === EE1);
+  r1e.x = 0.10; r1e.y = 0.10;
+  ts.dirtyMaps.mA = true;
+  ts._tuneRev = (ts._tuneRev || 0) + 1;
+  const r2 = await runSave();
+  J("next-save", { posts: posPosts(r2.payloads).map(
+    p => [p.source, p.x_m, p.y_m, p.z_m]) });
+}
+
+async function flow_save_refresh_fail() {
+  // (f) Position ack with a SWALLOWED refresh: the published ack survives
+  // in the local model and the draft reconciles to it.
+  const r1e = ts.draftReceivers.mA.find(q => q.source === EE1);
+  r1e.x = 0.10; r1e.y = 0.10;
+  ts.dirtyMaps.mA = true;
+  ts._tuneRev = (ts._tuneRev || 0) + 1;
+  swallowRefresh = true;
+  const r1 = await runSave();
+  swallowRefresh = false;
+  const acked = posPosts(r1.payloads)[0];
+  J("save-done", { toasts: r1.toasts.slice(), dirty: snap(ts.dirtyMaps) });
+  J("local-model", {
+    local: (ctx.state.model.scanner_positions_m[EE1] || {}),
+    acked: acked && [acked.x_m, acked.y_m] });
+  const row = ts.draftReceivers.mA.find(q => q.source === EE1);
+  J("draft", { x: row && row.x, y: row && row.y });
+}
+
+async function flow_removal_busy() {
+  // (d1) Removal attempted while a save holds the lock: zero calls,
+  // zero mutations, busy toast.
+  P.tuneTryAcquire(ts);
+  const before = { draft: snap(ts.draftReceivers),
+    baseline: snap(ts.editBaseline || {}), dirty: snap(ts.dirtyMaps) };
+  await runRemove("mA", "r1");
+  P.tuneRelease(ts);
+  J("removal-busy", { calls: calls.length, toasts: toasts.slice(),
+    unchanged: JSON.stringify({ draft: ts.draftReceivers,
+      dirty: ts.dirtyMaps }) === JSON.stringify(
+      { draft: before.draft, dirty: before.dirty }),
+    baselineUnchanged: JSON.stringify(ts.editBaseline || {}) ===
+      JSON.stringify(before.baseline) });
+}
+
+async function flow_removal_reject() {
+  // (d2) Backend ok:false: zero mutations, failure toast.
+  sc.opts.rejectRemove = true;
+  const before = { draft: snap(ts.draftReceivers),
+    baseline: snap(ts.editBaseline || {}), dirty: snap(ts.dirtyMaps) };
+  await runRemove("mA", "r1");
+  J("removal-reject", { calls: calls.length, toasts: toasts.slice(),
+    draftSame: JSON.stringify(ts.draftReceivers) ===
+      JSON.stringify(before.draft),
+    dirtySame: JSON.stringify(ts.dirtyMaps) ===
+      JSON.stringify(before.dirty) });
+}
+
+async function flow_removal_ok() {
+  // (d3) Acked removal: targeted cleanup only; an unrelated dirty edit
+  // on the SAME map survives with its coords/baseline/dirty intact;
+  // metadata removed; SPATIAL ENTRY PERSISTS (backend limitation — the
+  // victim therefore starts as an established receiver WITH one).
+  backend.spatial["gone-src"] = { x_m: 1.0, y_m: 1.0, z_m: 2.0,
+    floor_id: "downstairs" };
+  backend.meta.scanners["gone-src"] = { room: "r" };
+  ctx.state.model.scanner_positions_m["gone-src"] =
+    JSON.parse(JSON.stringify(backend.spatial["gone-src"]));
+  const r1e = ts.draftReceivers.mA.find(q => q.source === EE1);
+  r1e.x = 0.10; r1e.y = 0.10;   // unrelated dirty edit, same map
+  ts.dirtyMaps.mA = true;
+  ts._tuneRev = (ts._tuneRev || 0) + 1;
+  ts.draftReceivers.mA.push({ id: "rx_gone", label: "Gone", x: 0.5,
+    y: 0.5, room: "", source: "gone-src" });
+  ts._tuneRev = (ts._tuneRev || 0) + 1;
+  await runRemove("mA", "rx_gone");
+  const rows = ts.draftReceivers.mA;
+  J("removal-ok", { toasts: toasts.slice(),
+    ee1: rows.find(q => q.source === EE1),
+    goneGone: !rows.some(q => q.source === "gone-src"),
+    dirty: snap(ts.dirtyMaps),
+    metaGone: !backend.meta.scanners["gone-src"],
+    spatialPersists: Boolean(backend.spatial["gone-src"]),
+    ee1others: Object.keys(backend.spatial) });
+}
+
+const FLOWS = { flow_saveA_retryB_reset, flow_reset_dirty,
+  flow_height_blocked, flow_height_refresh_fail, flow_save_refresh_fail,
+  flow_removal_busy, flow_removal_reject, flow_removal_ok };
+
+let result;
+if (FLOW) {
+  try {
+    await FLOWS[SCENARIO]();
+  } catch (e) {
+    J("flow-threw", { error: String((e && e.stack) || e).slice(0, 800) });
+  }
+  result = { journal };
+} else {
+  // NOTE: sc.mutate already ran once right after sync init above; it
+  // must NOT run again here (place() would push duplicate rows).
+  const r = await runSave();
+  // Post-save rerender sync, as the live tab does on refresh.
+  P.tuneSyncTuneDrafts(ts, maps_list,
+    ctx.state.model.scanner_positions_m || {},
+    ctx.state.model.map_transforms || {});
+  const heightVisible = {};
+  for (const src of [GH, EE1]) {
+    heightVisible[src] = Boolean(
+      (ctx.state.model.scanner_positions_m || {})[src]);
+  }
+  result = { payloads: calls, toasts, dirty: ts.dirtyMaps,
+    draft: ts.draftReceivers, baseline: ts.editBaseline || {},
+    refreshCount, heightVisible,
+    fabric: backend.spatial, meta: backend.meta.scanners };
+}
+console.log(JSON.stringify(result));

--- a/tests/test_tune_save_fabric.py
+++ b/tests/test_tune_save_fabric.py
@@ -1,0 +1,432 @@
+# PadSpan HA — BLE Room-Presence Tracking for Home Assistant
+# Copyright (C) 2026 Garry Broeckling
+# Licensed under the GNU General Public License v3.0
+"""Tune Save transaction boundaries, tested through the SHIPPED callbacks.
+
+The lifecycle harness executes the actual registered callbacks from
+calibration.js (Tune Save, Height Save Z, Remove-from-floor, Reset) with a
+faithful backend model (spatial positions vs model metadata, deferred
+requests, swallowable refreshes). Single-save scenarios run init ->
+mutations -> Save -> refreshes -> rerender sync. Flow scenarios run
+multi-step callback sequences and report journals.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[1]
+_VIEWS = _ROOT / "custom_components" / "padspan_ha" / "www" / "padspan-ha" / "views"
+_SCRIPT = Path(__file__).parent / "js" / "tune_save_fabric.mjs"
+_CALIB = _VIEWS / "calibration.js"
+_NODE = Path.home() / ".nvm" / "versions" / "node" / "v24.14.1" / "bin" / "node"
+if not _NODE.exists():
+    _NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(not _NODE, reason="node is not installed")
+
+_EE1 = "aa:bb:cc:dd:ee:01"
+_EE2 = "aa:bb:cc:dd:ee:02"
+_GH_NEW = "google_home_3e759f07-new"
+
+
+def _run(scenario: str, views: Path = _VIEWS, timeout: int = 120) -> dict:
+    res = subprocess.run([str(_NODE), str(_SCRIPT), str(views), scenario],
+                         capture_output=True, text=True, encoding="utf-8",
+                         timeout=timeout)
+    assert res.returncode == 0, (
+        f"harness failed for {scenario}:\n{(res.stderr or '')[-2000:]}")
+    lines = [ln for ln in (res.stdout or "").strip().splitlines() if ln.startswith("{")]
+    assert lines, f"harness printed no JSON for {scenario}"
+    return json.loads(lines[-1])
+
+
+def _position_posts(out: dict) -> dict[str, dict]:
+    return {p["source"]: p for p in out.get("payloads", [])
+            if p.get("type") == "padspan_ha/fabric_scanner_position_set" and p.get("source")}
+
+
+def _all_position_posts(out: dict) -> list[dict]:
+    return [p for p in out.get("payloads", [])
+            if p.get("type") == "padspan_ha/fabric_scanner_position_set"]
+
+
+def _success_toasts(out: dict) -> list[str]:
+    return [t for t in out["toasts"] if "receiver positions saved" in t.lower()]
+
+
+def _journal(out: dict) -> dict[str, dict]:
+    return {e["ev"]: e for e in out.get("journal", [])}
+
+
+_V1_HANDLER = '''  saveBtn.addEventListener("click", async () => {
+    const dirtyIds = Object.keys(ts.dirtyMaps).filter(id => ts.dirtyMaps[id]);
+    if (!dirtyIds.length) { statusLbl.textContent = "No changes"; setTimeout(() => { statusLbl.textContent = ""; }, 2000); return; }
+    saveBtn.disabled = true;
+    statusLbl.textContent = "Saving...";
+    try {
+      // Save to fabric (metre-space authority), then sync fracs back to maps
+      for (const mapId of dirtyIds) {
+        const origMap = maps_list.find(m => m.id === mapId);
+        if (!origMap) continue;
+      }
+      // Clear dirty state BEFORE refresh so re-rendered view shows clean state
+      ts.dirtyMaps = {};
+      ts.selectedRx = null;
+      ctx.toast("Receiver positions saved");
+      // mapsRefresh refreshes data + triggers re-render (which updates dirty label & stamp)
+      await ctx.actions.mapsRefresh();
+    } catch (e) {
+      ctx.toast("Save failed: " + String(e), true);
+      statusLbl.textContent = "Error saving";
+      saveBtn.disabled = false;
+    }
+  });'''
+
+
+@pytest.fixture(scope="module")
+def v1_views(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """A views dir holding the PRE-FIX handler: current helpers (pure)
+    plus a calibration.js whose Tune Save block is the old no-op. The
+    Height/Remove/Reset handlers come along unchanged (they postdate the
+    fixture's purpose only where noted)."""
+    d = tmp_path_factory.mktemp("v1views")
+    shutil.copy(_VIEWS / "stack_transform.js", d / "stack_transform.js")
+    shutil.copy(_VIEWS / "tune_save_plan.js", d / "tune_save_plan.js")
+    src = _CALIB.read_text(encoding="utf-8")
+    head = '  saveBtn.addEventListener("click", async () => {'
+    mark = "const dirtyIds = Object.keys(ts.dirtyMaps)"
+    h = src.find(head)
+    while h >= 0:
+        if mark in src[h:h + 2600]:
+            break
+        h = src.find(head, h + 1)
+    assert h >= 0, "current Tune Save handler not found"
+    tail = "  });\n\n  // Reset button"
+    t = src.find(tail, h)
+    assert t > h, "save/reset anchor moved"
+    (d / "calibration.js").write_text(
+        src[:h] + _V1_HANDLER + src[t + len("  });"):], encoding="utf-8")
+    return d
+
+
+def test_save_handler_names_resolve_in_module_scope() -> None:
+    src = _CALIB.read_text(encoding="utf-8")
+    assert re.search(r"import\(`\./tune_save_plan\.js", src)
+    assert "tuneSavePlanInit({ mapFracToMetres, metresToMapFrac });" in src
+
+
+def test_single_shared_seed_routine_for_init_and_reset() -> None:
+    src = _CALIB.read_text(encoding="utf-8")
+    assert src.count("tuneSyncTuneDrafts(ts, maps_list,") >= 2
+    reset = src[src.find('resetBtn.addEventListener("click"',
+                         src.find("Receiver Position Tuning")):]
+    reset = reset[:reset.find("ctrlRow.appendChild(saveBtn)")]
+    assert "tuneSyncTuneDrafts" in reset
+    assert "(m.receivers || [])" not in reset.replace(
+        "tuneSyncTuneDrafts(ts, maps_list,", ""), \
+        "Reset still reseeds map pins directly"
+
+
+def test_moved_and_new_receivers_reach_the_fabric() -> None:
+    out = _run("moved")
+    posts = _position_posts(out)
+    assert _EE1 in posts, f"moved receiver never posted: {out['payloads']}"
+    assert _GH_NEW in posts, f"new google_home pin never posted: {out['payloads']}"
+    assert _EE2 not in posts, "receiver from a CLEAN map was rewritten"
+    assert _success_toasts(out), f"no success toast: {out['toasts']}"
+    assert out["dirty"] == {}, f"dirty not cleared: {out['dirty']}"
+    assert out["refreshCount"] >= 2
+
+
+def test_new_pin_converts_through_the_rotated_sheared_transform() -> None:
+    from unittest.mock import AsyncMock, MagicMock
+
+    from custom_components.padspan_ha.model_store import ModelStore
+
+    mdl = ModelStore.__new__(ModelStore)
+    mdl.hass = MagicMock()
+    mdl.store = AsyncMock()
+    mdl.data = {"map_transforms": {
+        "mA": {"origin_x_m": 1.3, "origin_y_m": -0.98, "scale_x_m": 18.01,
+               "scale_y_m": 12.04, "rotation_rad": -0.015, "shear_rad": 0.008,
+               "floor_id": "downstairs"}}}
+    mdl.fabric = None
+    expected = mdl.map_frac_to_metres(0.0289, 0.0485, "mA")
+
+    pin = _position_posts(_run("moved"))[_GH_NEW]
+    assert (pin["x_m"], pin["y_m"]) == pytest.approx(expected, abs=5e-4)
+    assert pin["floor_id"] == "downstairs"
+
+
+def test_stale_unedited_pin_never_posts() -> None:
+    out = _run("stale")
+    posts = _position_posts(out)
+    assert list(posts) == [_GH_NEW], f"stale source posted: {posts}"
+    assert _success_toasts(out)
+
+
+def test_reconciled_untouched_pin_never_posts() -> None:
+    out = _run("untouched")
+    posts = _position_posts(out)
+    assert list(posts) == [_GH_NEW], f"rounded untouched pin posted: {posts}"
+    assert _success_toasts(out)
+
+
+def test_existing_height_preserved_on_move() -> None:
+    pin = _position_posts(_run("moved"))[_EE1]
+    assert pin["z_m"] == pytest.approx(1.2)
+
+
+def test_conflicting_duplicate_sources_refused() -> None:
+    out = _run("conflict")
+    assert _position_posts(out) == {}, f"conflict posted: {out['payloads']}"
+    assert out["dirty"].get("mA") is True and out["dirty"].get("mB") is True
+    assert not _success_toasts(out)
+
+
+def test_missing_fabric_conflict_refused_on_both() -> None:
+    out = _run("missingconflict")
+    assert _position_posts(out) == {}, f"dedup wrote first: {out['payloads']}"
+    assert out["dirty"].get("mA") is True and out["dirty"].get("mB") is True
+    assert not _success_toasts(out)
+
+
+def test_identical_cross_map_candidates_single_request() -> None:
+    """Finding 5: identical candidates group to ONE request; on failure
+    ALL owner maps stay pending; the success count is unique requests."""
+    out = _run("dedupfail")
+    posts = _all_position_posts(out)
+    assert len(posts) == 1, f"expected one grouped request: {posts}"
+    assert posts[0]["source"] == _GH_NEW
+    assert out["dirty"].get("mA") is True and out["dirty"].get("mB") is True, \
+        f"failure must keep ALL owners pending: {out['dirty']}"
+    assert not _success_toasts(out)
+
+
+def test_missing_fabric_pin_saved_without_drag() -> None:
+    out = _run("missingfabric")
+    posts = _position_posts(out)
+    assert list(posts) == [_GH_NEW], f"expected only the missing pin: {posts}"
+    assert out["heightVisible"][_GH_NEW] is True
+    assert _success_toasts(out)
+
+
+def test_truly_unchanged_session_stays_silent() -> None:
+    out = _run("nodrag")
+    assert out["payloads"] == []
+    assert out["toasts"] == []
+    assert out["refreshCount"] == 0
+
+
+def test_save_refresh_exposes_height_and_reconciles_draft() -> None:
+    out = _run("moved")
+    assert out["heightVisible"][_GH_NEW] is True
+    assert out["heightVisible"][_EE1] is True
+    draft = {r["source"]: r for r in out["draft"]["mA"]}
+    assert set(draft) >= {_EE1, _GH_NEW}
+    assert draft[_EE1]["id"] == "r1" and draft[_GH_NEW]["label"] == "Spare Mini"
+
+
+def test_unmeasured_map_refuses_loudly_and_keeps_dirty() -> None:
+    out = _run("unmeasured")
+    assert _position_posts(out) == {}
+    assert out["dirty"].get("mB") is True
+    assert not _success_toasts(out)
+
+
+def test_singular_transform_refuses() -> None:
+    out = _run("singular")
+    assert _position_posts(out) == {}
+    assert out["dirty"].get("mA") is True
+    assert not _success_toasts(out)
+
+
+def test_negative_scale_refuses() -> None:
+    out = _run("negscale")
+    assert _position_posts(out) == {}
+    assert out["dirty"].get("mA") is True
+    assert not _success_toasts(out)
+
+
+def test_invalid_coords_are_failed_work_not_silent_skip() -> None:
+    out = _run("invalid")
+    assert _position_posts(out) == {}
+    assert out["dirty"].get("mA") is True, "invalid row cleared dirty"
+    assert not _success_toasts(out), f"false success: {out['toasts']}"
+
+
+def test_missing_map_preserves_and_reports_error() -> None:
+    out = _run("missingmap")
+    assert _position_posts(out) == {}
+    assert out["dirty"].get("mGhost") is True, "missing-map dirty flag lost"
+    assert not _success_toasts(out), f"false success: {out['toasts']}"
+
+
+def test_partial_failure_saves_good_map_keeps_bad_dirty() -> None:
+    out = _run("partial")
+    posts = _position_posts(out)
+    assert _EE1 in posts and _GH_NEW not in posts
+    assert out["dirty"].get("mB") is True
+    assert out["dirty"].get("mA") is not True
+    assert not _success_toasts(out)
+
+
+def test_ok_false_treated_as_failure() -> None:
+    out = _run("reject")
+    assert out["dirty"].get("mA") is True
+    assert not _success_toasts(out)
+
+
+def test_thrown_write_keeps_map_dirty() -> None:
+    out = _run("throw")
+    assert out["dirty"].get("mA") is True
+    assert not _success_toasts(out)
+
+
+def test_concurrent_edit_during_save_keeps_dirty_and_warns() -> None:
+    out = _run("concurrent")
+    assert out["dirty"].get("mA") is True
+    assert not _success_toasts(out)
+    assert any("during save" in t for t in out["toasts"])
+
+
+def test_saveA_retryB_reset_flow() -> None:
+    """Finding 1(a): deferred ack A, drag B mid-save, ack, retry posts B
+    only with A's exact metres, then Reset and a fresh render both show B."""
+    out = _run("flow_saveA_retryB_reset")
+    j = _journal(out)
+    assert j["saveA-posts"]["n"] == 1
+    assert j["saveA-done"]["dirty"] == {"mA": True}
+    assert "edits changed during save" in " ".join(j["saveA-done"]["toasts"])
+    # Baseline advanced ONLY to submitted A, not the newer draft.
+    assert j["saveA-done"]["baseline"]["mA"][_EE1] == {"x": 0.1, "y": 0.1}
+    assert len(j["retry"]["posts"]) == 1, j["retry"]
+    src, xm, ym = j["retry"]["posts"][0]
+    assert src == _EE1
+    assert (xm, ym) == pytest.approx((4.918, 1.374), abs=2e-3), \
+        "retry must send B's metres, not A's"
+    assert j["after-reset"]["x"] == pytest.approx(0.2, abs=1e-3)
+    assert j["after-reset"]["dirty"] == {}
+    assert j["after-reset"]["baseline"]["x"] == pytest.approx(0.2, abs=1e-3)
+    assert j["fresh-render"]["x"] == pytest.approx(0.2, abs=1e-3)
+    assert j["backend"]["spatial"][_EE1]["x_m"] == pytest.approx(4.918, abs=2e-3)
+
+
+def test_reset_dirty_retains_fabric_coords_and_baseline() -> None:
+    """Finding 2(b): Reset on a dirty map restores fabric coords AND the
+    fabric-only pin WITH its baseline; dirty cleared."""
+    out = _run("flow_reset_dirty")
+    j = _journal(out)
+    ar = j["after-reset"]
+    assert (ar["ee1"]["x"], ar["ee1"]["y"]) == pytest.approx((0.2031, 0.5012), abs=1e-3)
+    assert ar["fabonly"]["source"] == "fabric-only-src"
+    assert ar["baseline"]["fabric-only-src"]["x"] == pytest.approx(
+        ar["fabonly"]["x"], abs=1e-12)
+    assert ar["dirty"] == {}
+
+
+def test_height_blocked_then_carried() -> None:
+    """Finding 3: position Save attempted during a pending Height is
+    refused (zero posts); after the height lands, the next position Save
+    carries the new height."""
+    out = _run("flow_height_blocked")
+    j = _journal(out)
+    assert j["height-pending"]["heightCalls"] == 1
+    assert j["save-during-height"]["posts"] == 0
+    assert any("try again" in t for t in j["save-during-height"]["toasts"])
+    assert j["height-done"]["localZ"] == pytest.approx(1.7)
+    assert j["height-done"]["backendZ"] == pytest.approx(1.7)
+    assert len(j["next-save"]["posts"]) == 1
+    assert j["next-save"]["posts"][0][0] == _EE1
+    assert j["next-save"]["posts"][0][1] == pytest.approx(1.7)
+
+
+def test_height_survives_swallowed_refresh() -> None:
+    """Finding 3: acked height survives a swallowed refresh locally, and
+    the next position Save carries it (not the 2.4 default)."""
+    out = _run("flow_height_refresh_fail")
+    j = _journal(out)
+    assert j["height-acked"]["localZ"] == pytest.approx(1.7)
+    assert j["after-swallowed-refresh"]["localZ"] == pytest.approx(1.7)
+    src, xm, ym, zm = j["next-save"]["posts"][0]
+    assert src == _EE1 and zm == pytest.approx(1.7), \
+        f"position save must carry 1.7, not default: {j['next-save']}"
+
+
+def test_acked_position_survives_failed_refresh() -> None:
+    """Finding 1(f): acked position published locally survives a swallowed
+    refresh; draft reconciles to it."""
+    out = _run("flow_save_refresh_fail")
+    j = _journal(out)
+    assert j["save-done"]["dirty"] == {}
+    assert (j["local-model"]["local"]["x_m"],
+            j["local-model"]["local"]["y_m"]) == pytest.approx(
+                tuple(j["local-model"]["acked"]), abs=1e-9)
+    assert (j["draft"]["x"], j["draft"]["y"]) == pytest.approx((0.1, 0.1), abs=1e-3), \
+        "draft must still show the submitted fractions"
+
+
+def test_removal_busy_leaves_everything_unchanged() -> None:
+    """Finding 4: removal attempted while busy: zero calls, zero
+    mutations, busy toast."""
+    out = _run("flow_removal_busy")
+    j = _journal(out)
+    assert j["removal-busy"]["calls"] == 0
+    assert j["removal-busy"]["unchanged"] is True
+    assert j["removal-busy"]["baselineUnchanged"] is True
+    assert any("try again" in t for t in j["removal-busy"]["toasts"])
+
+
+def test_removal_rejected_leaves_everything_unchanged() -> None:
+    """Finding 4: backend ok:false: zero mutations, failure toast."""
+    out = _run("flow_removal_reject")
+    j = _journal(out)
+    assert j["removal-reject"]["calls"] == 1
+    assert j["removal-reject"]["draftSame"] is True
+    assert j["removal-reject"]["dirtySame"] is True
+    assert any("failed" in t.lower() for t in j["removal-reject"]["toasts"])
+
+
+def test_removal_ok_targeted_cleanup_and_backend_truth() -> None:
+    """Finding 4: acked removal cleans ONLY the targeted row/baseline,
+    preserves an unrelated dirty edit on the SAME map, removes metadata —
+    and the spatial entry PERSISTS (disclosed backend limitation)."""
+    out = _run("flow_removal_ok")
+    j = _journal(out)
+    r = j["removal-ok"]
+    assert r["goneGone"] is True
+    assert (r["ee1"]["x"], r["ee1"]["y"]) == pytest.approx((0.1, 0.1)), \
+        "unrelated same-map edit must survive with its coords"
+    assert r["dirty"] == {"mA": True}
+    assert r["metaGone"] is True, "backend metadata must be removed"
+    assert r["spatialPersists"] is True, \
+        "spatial entry persists server-side (known backend limitation)"
+    assert _EE1 in r["ee1others"]
+
+
+@pytest.mark.parametrize("scenario", ["moved", "missingfabric", "untouched"])
+def test_prefix_handler_posts_nothing(v1_views: Path, scenario: str) -> None:
+    out = _run(scenario, v1_views)
+    assert _position_posts(out) == {}
+    assert out["heightVisible"][_GH_NEW] is False
+
+
+@pytest.mark.parametrize("scenario", ["stale", "untouched", "missingconflict",
+                                      "negscale", "invalid", "conflict",
+                                      "dedupfail", "singular", "missingmap",
+                                      "reject", "concurrent"])
+def test_new_guards_fail_on_prefix_handler(v1_views: Path, scenario: str) -> None:
+    out = _run(scenario, v1_views)
+    posts = _position_posts(out)
+    cleared = not out["dirty"]
+    false_success = bool(_success_toasts(out))
+    assert cleared or false_success or \
+        (scenario == "stale" and _EE1 in posts), \
+        f"v1 unexpectedly behaves for {scenario}: {out}"

--- a/tests/test_tune_save_plan.py
+++ b/tests/test_tune_save_plan.py
@@ -1,0 +1,236 @@
+"""Direct unit tests for the Tune save-plan helpers (pure, no DOM)."""
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[1]
+_VIEWS = _ROOT / "custom_components" / "padspan_ha" / "www" / "padspan-ha" / "views"
+_NODE = Path.home() / ".nvm" / "versions" / "node" / "v24.14.1" / "bin" / "node"
+if not _NODE.exists():
+    _NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(not _NODE, reason="node is not installed")
+
+_DRIVER = r"""
+import { tuneSavePlanInit, tuneDiffMapDraft, tuneMissingFabricPins,
+  tuneConflictingSources, tuneReconcileDraft, tunePlacementReadable,
+  tuneSyncTuneDrafts, tuneSnapBaseline,
+  tuneTryAcquire, tuneRelease } from 'PLAN';
+import { mapFracToMetres, metresToMapFrac } from 'STACK';
+tuneSavePlanInit({ mapFracToMetres, metresToMapFrac });
+const tf = (o) => Object.assign({ origin_x_m: 0, origin_y_m: 0,
+  scale_x_m: 20, scale_y_m: 15, rotation_rad: 0, shear_rad: 0,
+  floor_id: 'main' }, o);
+const out = {};
+// readability gates (backend contract: positive scales, >=1mm reach)
+out.empty = tunePlacementReadable({});
+out.noScales = tunePlacementReadable({ origin_x_m: 0, origin_y_m: 0 });
+out.zero = tunePlacementReadable(tf({ scale_x_m: 0 }));
+out.negscale = tunePlacementReadable(tf({ scale_x_m: -20 }));
+out.negscaleY = tunePlacementReadable(tf({ scale_y_m: -15 }));
+out.singular = tunePlacementReadable(tf({ shear_rad: Math.PI / 2 }));
+out.good = tunePlacementReadable(tf({ rotation_rad: 0.3, shear_rad: 0.05 }));
+// diff needs baseline difference or missing pin — never fabric disagreement
+const fab = { 's1': { x_m: 4.0, y_m: 3.0, z_m: 1.2, floor_id: 'main' } };
+const map = { id: 'm', floor_id: 'main' };
+const T = { m: tf() };
+const staleRows = [
+  { id: 'a', x: 0.9, y: 0.9, room: 'R', source: 's1' },  // stale vs fabric
+  { id: 'c', x: 0.5, y: 0.5, source: 's2' },              // missing pin
+];
+const staleBase = { s1: { x: 0.9, y: 0.9 }, s2: { x: 0.5, y: 0.5 } };
+out.staleUntouched = tuneDiffMapDraft(map, staleRows, fab, T, staleBase, true);
+const movedRows = [
+  { id: 'a', x: 0.21, y: 0.2, room: 'R', source: 's1' },
+  { id: 'c', x: 0.5, y: 0.5, source: 's2' },
+];
+out.moved = tuneDiffMapDraft(map, movedRows, fab, T, staleBase, false);
+out.movedMissing = tuneDiffMapDraft(map, movedRows, fab, T, staleBase, true);
+out.invalid = tuneDiffMapDraft(map,
+  [{ id: 'a', x: 'not-a-number', y: 0.2, source: 's9' }],
+  fab, T, { s9: { x: 0.1, y: 0.2 } }, false);
+out.sourceless = tuneDiffMapDraft(map,
+  [{ id: 'x', x: 0.5, y: 0.5 }], fab, T, {}, true);
+// missing helper returns EVERY occurrence incl. floors
+out.missingAll = tuneMissingFabricPins(
+  [{ id: 'm1', floor_id: 'main' }, { id: 'm2', floor_id: 'up' }],
+  { m1: [{ source: 'dup', x: 0.1, y: 0.1 }],
+    m2: [{ source: 'dup', x: 0.9, y: 0.9 }] },
+  {}, { m1: tf(), m2: tf() });
+// conflicts incl. floors
+out.conflict = tuneConflictingSources([
+  { source: 's1', x_m: 1, y_m: 1, floor_id: 'main' },
+  { source: 's1', x_m: 5, y_m: 1, floor_id: 'main' },
+]);
+out.floorConflict = tuneConflictingSources([
+  { source: 's1', x_m: 1, y_m: 1, floor_id: 'main' },
+  { source: 's1', x_m: 1, y_m: 1, floor_id: 'up' },
+]);
+out.noConflict = tuneConflictingSources([
+  { source: 's1', x_m: 1, y_m: 1, floor_id: 'main' },
+  { source: 's1', x_m: 1.0001, y_m: 1, floor_id: 'main' },
+]);
+// reconcile keeps FULL precision + metadata, filters footprint/floor
+const fabR = {
+  's1': { x_m: 4.0, y_m: 3.0, z_m: 1.2, floor_id: 'main' },
+  'far': { x_m: 400.0, y_m: 300.0, floor_id: 'main' },
+  'otherfloor': { x_m: 4.0, y_m: 3.0, floor_id: 'up' },
+};
+out.recon = tuneReconcileDraft(map,
+  [{ id: 'keep-me', label: 'Kitchen', x: 0, y: 0, room: 'K', source: 's1' },
+   { id: 'stale', label: 'Old', x: 0.1, y: 0.1, room: '', source: 'gone' }],
+  fabR, T, false);
+out.reconDirty = tuneReconcileDraft(map, [{ id: 'x', source: 's1' }], fabR, T, true);
+// sync routine: fresh seed + reconcile + baselines; model-late reconcile;
+// dirty maps never touched (coords AND baselines preserved)
+{
+  const ts = {};
+  const maps = [{ id: 'm', floor_id: 'main', updated: 't0',
+    receivers: [{ id: 'r1', label: 'RX', x: 0, y: 0, room: 'R', source: 's1' }] }];
+  const fabS = { 's1': { x_m: 4.0, y_m: 3.0, z_m: 1.2, floor_id: 'main' } };
+  const model = { scanner_positions_m: fabS, map_transforms: T };
+  tuneSyncTuneDrafts(ts, maps, model.scanner_positions_m,
+    model.map_transforms);
+  const snap = (o) => JSON.parse(JSON.stringify(o));
+  out.syncSeed = { draft: snap(ts.draftReceivers),
+    base: snap(ts.editBaseline), dirty: snap(ts.dirtyMaps) };
+  // model arriving/changing later reconciles clean maps AND baselines
+  const fabS2 = { 's1': { x_m: 6.0, y_m: 3.0, z_m: 1.2, floor_id: 'main' } };
+  tuneSyncTuneDrafts(ts, maps, fabS2, T);
+  out.syncModelChange = { draft: snap(ts.draftReceivers.m[0]),
+    base: snap(ts.editBaseline.m.s1) };
+  // dirty maps: neither coords nor baselines move, flags untouched
+  ts.dirtyMaps = { m: true };
+  maps[0].receivers = [{ id: 'r1', label: 'RX', x: 0.99, y: 0.99, room: 'R', source: 's1' }];
+  maps[0].updated = 't1';
+  tuneSyncTuneDrafts(ts, maps, fabS2, T);
+  out.syncDirtyKept = { draft: snap(ts.draftReceivers.m),
+    base: snap(ts.editBaseline.m) };
+}
+// mutex primitives (the guarded Height/Remove/Save callbacks in the
+// view own the lock; lifecycle tests cover the sequences end to end)
+{
+  const ts = {};
+  out.acquire = tuneTryAcquire(ts);
+  out.reacquire = tuneTryAcquire(ts);
+  tuneRelease(ts);
+  out.afterRelease = tuneTryAcquire(ts);
+  tuneRelease(ts);
+  out.releaseEmpty = (tuneRelease({}), true)[1];
+}
+// baseline snapshots carry exact fractions, first-wins per source
+out.snap = tuneSnapBaseline([
+  { id: 'a', x: 0.1, y: 0.2, source: 's1' },
+  { id: 'b', x: 0.3, y: 0.4, source: 's1' },
+  { id: 'c', x: 0.5, y: 0.5 },
+]);
+console.log(JSON.stringify(out));
+"""
+
+
+@pytest.fixture(scope="module")
+def plan() -> dict:
+    script = _DRIVER.replace(
+        "from 'PLAN'", f"from '{(_VIEWS / 'tune_save_plan.js').as_uri()}'")
+    script = script.replace(
+        "from 'STACK'", f"from '{(_VIEWS / 'stack_transform.js').as_uri()}'")
+    res = subprocess.run([str(_NODE), "--input-type=module", "-e", script],
+                         capture_output=True, text=True, encoding="utf-8", timeout=60)
+    assert res.returncode == 0, f"plan driver failed:\n{res.stderr[-3000:]}"
+    return json.loads(res.stdout.strip().splitlines()[-1])
+
+
+def test_readability_gates_match_backend(plan: dict) -> None:
+    assert plan["empty"] is False
+    assert plan["noScales"] is False
+    assert plan["zero"] is False
+    assert plan["negscale"] is False
+    assert plan["negscaleY"] is False
+    assert plan["singular"] is False
+    assert plan["good"] is True
+
+
+def test_stale_baseline_match_never_posts(plan: dict) -> None:
+    """Finding 1: a row equal to its baseline posts nothing even when its
+    metres disagree with the fabric — disagreement is not an edit. The
+    fabric-missing s2 row still joins via includeMissing."""
+    d = plan["staleUntouched"]
+    assert [w["source"] for w in d["writes"]] == ["s2"], d
+    assert d["invalid"] == [] and d["refused"] is False
+
+
+def test_moved_and_missing_post_with_height_ridealong(plan: dict) -> None:
+    d = plan["movedMissing"]
+    by_src = {w["source"]: w for w in d["writes"]}
+    assert set(by_src) == {"s1", "s2"}, d
+    assert by_src["s1"].get("z_m") == 1.2, "existing height must ride along"
+    assert "z_m" not in by_src["s2"], "new entries must omit z"
+    assert plan["moved"]["writes"] == [by_src["s1"]], \
+        "without includeMissing only the edited row posts"
+
+
+def test_invalid_and_sourceless(plan: dict) -> None:
+    assert plan["invalid"]["invalid"] == ["s9"]
+    assert plan["invalid"]["writes"] == []
+    assert plan["sourceless"]["skipped"] == [""]
+    assert plan["sourceless"]["writes"] == []
+
+
+def test_missing_returns_all_occurrences(plan: dict) -> None:
+    assert plan["missingAll"] == [
+        {"mapId": "m1", "source": "dup"},
+        {"mapId": "m2", "source": "dup"}], plan["missingAll"]
+
+
+def test_conflicts(plan: dict) -> None:
+    assert plan["conflict"] == ["s1"]
+    assert plan["floorConflict"] == ["s1"], "floor-only moves must conflict"
+    assert plan["noConflict"] == []
+
+
+def test_reconcile_full_precision_and_metadata(plan: dict) -> None:
+    by_src = {r["source"]: r for r in plan["recon"]}
+    assert by_src["s1"]["id"] == "keep-me"
+    assert by_src["s1"]["label"] == "Kitchen" and by_src["s1"]["room"] == "K"
+    # Full inverse precision: exactly 0.2, not a 4dp rounding (finding 1).
+    assert by_src["s1"]["x"] == 0.2 and by_src["s1"]["y"] == 0.2, by_src["s1"]
+    assert "far" not in by_src and "otherfloor" not in by_src
+    assert by_src["gone"]["id"] == "stale"
+
+
+def test_reconcile_dirty_passthrough(plan: dict) -> None:
+    assert plan["reconDirty"] is None
+
+
+def test_sync_seeds_baselines_and_reconciles(plan: dict) -> None:
+    s = plan["syncSeed"]
+    assert s["dirty"] == {}
+    r1 = next(r for r in s["draft"]["m"] if r["source"] == "s1")
+    assert (r1["x"], r1["y"]) == pytest.approx((0.2, 0.2)), r1
+    assert s["base"]["m"]["s1"] == {"x": r1["x"], "y": r1["y"]}, \
+        "baseline must follow reconciled coords"
+
+
+def test_sync_model_change_reconciles_clean(plan: dict) -> None:
+    r1 = plan["syncModelChange"]["draft"]
+    assert (r1["x"], r1["y"]) == pytest.approx((0.3, 0.2)), r1
+    assert plan["syncModelChange"]["base"] == {"x": r1["x"], "y": r1["y"]}
+
+
+def test_sync_dirty_never_touched(plan: dict) -> None:
+    k = plan["syncDirtyKept"]
+    assert k["draft"][0]["x"] == pytest.approx(0.3), k["draft"]
+    assert k["base"]["s1"] == {"x": 0.3, "y": 0.2}, \
+        "dirty map baselines must not move either"
+
+
+def test_mutex_primitives(plan: dict) -> None:
+    assert plan["acquire"] is True and plan["reacquire"] is False
+    assert plan["afterRelease"] is True
+
+
+def test_snap_baseline(plan: dict) -> None:
+    assert plan["snap"] == {"s1": {"x": 0.1, "y": 0.2}}, plan["snap"]


### PR DESCRIPTION
## Bug

In Calibration > Tune, placing a receiver on a map and pressing Save looked
successful ("Receiver positions saved") but wrote nothing to the positioning
fabric: the Save handler iterated dirty maps with an empty loop body. A
newly placed receiver therefore never gained a fabric entry, and its
"Height above floor" input never appeared.

Repro: Calibration > Tune > place any unplaced radio via double-click >
Save. Toast claims success; the receiver has no fabric position and no
height field.

## Fix behavior

- Fresh placements and dragged (moved) receivers save correct fabric
  metres through each map's measured transform (rotation/shear aware).
- New receivers take the standard backend default height; moved receivers
  keep their existing mounting height; untouched receivers are never
  rewritten, however stale their pins.
- Missing-fabric pins join the save even from clean maps; same-source
  conflicts across maps are refused on all owners instead of last-write-win.
- Unreadable placements (missing/zero/negative/singular scales) and
  invalid coordinates refuse loudly, keep their maps dirty, and never
  toast success. Backend rejections (ok:false) and thrown requests are
  treated as failures; partial failures keep only failed maps dirty.
- Position, Height and Remove writers share a session mutex: a busy
  session toasts and changes nothing. Height and removal acks are
  published locally so a swallowed refresh cannot revert them.
- Initial render and Reset share one seed/reconcile routine: saved moves
  survive Reset and fresh sessions; dirty drafts are never touched.

## Tests

- tests/js/tune_save_fabric.mjs: lifecycle harness executing the shipped
  callbacks (17 single-save scenarios + 8 multi-step flows with deferred
  acks, swallowed refreshes, busy/rejected backends).
- tests/test_tune_save_fabric.py (44) and tests/test_tune_save_plan.py
  (13), each run against a verbatim pre-fix handler copy to prove they
  fail before the fix.
- Full suite: 1675 passed, 0 failed; render smoke green; diff check clean.

Not tested: live Home Assistant or a real browser session (out of scope
for this change); no deployment or migration involved.

Note (pre-existing, unchanged by this PR): the backend
`fabric_scanner_remove` endpoint deletes a scanner's model metadata only;
its fabric spatial entry persists server-side. The removal callback now
at least refuses safely (busy/rejected paths change nothing) but does not
repair that backend behavior.
