### PR TITLE
fix(maps): preserve receiver touch target while dragging

### DIFF
--- a/custom_components/padspan_ha/www/padspan-ha/views/maps.js
+++ b/custom_components/padspan_ha/www/padspan-ha/views/maps.js
@@ -3186,8 +3186,16 @@ function _makeDraggable(node, receiver, container, onMoved=null, isEnabled=null,
     receiver.y = clamp01(y);
     node.style.left = `${Math.round(receiver.x*10000)/100}%`;
     node.style.top  = `${Math.round(receiver.y*10000)/100}%`;
-    if(onMoved) onMoved();
+    // NOTE: no onMoved() here - the Edit tab's onMoved rebuilds every marker
+    // (renderAll), which deletes the active touch target mid-gesture. The
+    // browser then retargets the rest of the touch stream to the detached
+    // node, so on mobile only the first touchmove step applied and the marker
+    // crept a short distance and stopped (desktop mouse re-hit-tests each
+    // event, which is why only touch was affected). The commit render runs
+    // once on release in onUp below.
   };
+  // Single commit point: refresh the marker list + summary once the gesture
+  // ends, so the dragged node stays connected for the whole touch stream.
   const onUp = ()=>{
     if(!dragging) return;
     dragging = false;
@@ -3203,6 +3211,10 @@ function _makeDraggable(node, receiver, container, onMoved=null, isEnabled=null,
   node.addEventListener("touchstart", onDown, {passive:false});
   window.addEventListener("touchmove", onMove, {passive:false});
   window.addEventListener("touchend", onUp);
+  // An OS-cancelled gesture (call, alert, browser takeover) must release the
+  // drag the same way a lift does - otherwise dragging/_editDragging stay
+  // stuck true and the poll re-render guard freezes the panel until reload.
+  window.addEventListener("touchcancel", onUp);
 }
 
 // Format receiver list as a numbered text summary (for debug display).


### PR DESCRIPTION
## Symptom

On the Mapping page (Edit tab), tapping Add (or Add receiver) places the Bluetooth receiver marker fine, but dragging it on a phone moves the marker only a small distance and then it stops — continued finger movement does nothing, which can read as the marker going the wrong way. Desktop mouse dragging works normally.

## Root cause

`_makeDraggable` in `custom_components/padspan_ha/www/padspan-ha/views/maps.js` called the Edit tab's `onMoved()` (`renderAll()` + `refreshList()`) on **every** move event. `renderAll()` deletes and recreates every `.marker` node, so the first `touchmove` destroyed the active touch target mid-gesture. The browser retargets the rest of that touch stream to the detached node, starving `window` of further `touchmove` events after the first step. Desktop mouse re-hit-tests on every event, which is why only touch was affected. Verified with an isolated harness driving the verbatim helper with real mobile touch input: 150px finger drag moved the marker 0.043 of map width vs 0.429 expected (exactly 1/10th — one step, then silence).

## Solution

- `onMove` now does imperative live movement only (receiver model `x/y` + the marker's own `left/top`); no render during the gesture, so the touch target survives.
- The marker list/summary render commits once on release (`onUp`). Desktop marker movement is continuous during the drag; the list refresh is deferred till release.
- Added `touchcancel` → same release path, so an OS-cancelled gesture can't leave `dragging`/`_editDragging` stuck true (which would freeze panel re-renders until reload).

Scope is the receiver Edit-tab drag helper only; the `calibration.js` mobile picker and all other drag paths are untouched.

## Test evidence

Isolated real-touch repro (Chromium, Pixel-7 mobile emulation, 150px drag on a 350px stage; desktop check 150px on 600px):

- Original code: 1/10 touchmoves applied, marker `dx=0.043` vs `0.429` expected — failure reproduced.
- Fixed code, 9/9 checks pass: mobile full-distance `dx=0.4286`, all 10 moves delivered, marker connected throughout, single commit render on release, y stable; desktop full-distance `dx=0.25`; tap-select parity with original; `touchcancel` releases; disabled mode (other tabs) doesn't move.
- `node --check` clean on the modified file.

Honest scope: the harness covers the drag helper's touch/mouse/cancel behaviour only — not saving, calibration, or other Mapping features.
